### PR TITLE
Refactor scripts to use pathlib for base paths

### DIFF
--- a/adv_campaigns_details_import_flat.py
+++ b/adv_campaigns_details_import_flat.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
@@ -6,9 +6,9 @@ import time
 from datetime import datetime
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path  = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path  = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB: {db_path}")
 print(f"XLSX: {xls_path}")

--- a/adv_campaigns_import_flat.py
+++ b/adv_campaigns_import_flat.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
@@ -6,9 +6,9 @@ import time
 from datetime import datetime
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path  = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path  = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB: {db_path}")
 print(f"XLSX: {xls_path}")

--- a/adv_fullstats_import_flat.py
+++ b/adv_fullstats_import_flat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
@@ -8,9 +8,9 @@ import random
 from datetime import datetime, timedelta
 
 # ---------- Paths ----------
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path  = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path  = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB:  {db_path}")
 print(f"XLS: {xls_path}")

--- a/finotchet_import.py
+++ b/finotchet_import.py
@@ -1,11 +1,11 @@
-import os
+from pathlib import Path
 import sqlite3
 import json
 import ast
 
 # --- Пути к базе ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path = os.path.join(base_dir, "finmodel.db")
+base_dir = Path(__file__).resolve().parent.parent
+db_path = base_dir / "finmodel.db"
 
 # --- Список всех WB-полей ---
 WB_FIELDS = [

--- a/katalog.py
+++ b/katalog.py
@@ -1,13 +1,13 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import time
 import pandas as pd
 
 # 📌 Пути к базе и Excel-файлу
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 # 📌 Чтение таблицы организаций
 df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")

--- a/nm_report_history_import.py
+++ b/nm_report_history_import.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
@@ -6,9 +6,9 @@ import time
 from datetime import datetime, timedelta
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path  = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path  = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB:  {db_path}")
 print(f"XLS: {xls_path}")

--- a/orderswb_import_flat.py
+++ b/orderswb_import_flat.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import json
@@ -7,9 +7,9 @@ import pandas as pd
 from datetime import datetime
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Получаем период загрузки из Excel ---
 df_settings = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")

--- a/paid_storage_import_flat.py
+++ b/paid_storage_import_flat.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
@@ -6,9 +6,9 @@ import time
 from datetime import datetime, timedelta
 
 # ---------------- Paths ----------------
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path  = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path  = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB:  {db_path}")
 print(f"XLS: {xls_path}")

--- a/paid_storage_import_incremental.py
+++ b/paid_storage_import_incremental.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
@@ -6,9 +6,9 @@ import time
 from datetime import datetime, timedelta, date
 
 # ---------- Paths ----------
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path  = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path  = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB:  {db_path}")
 print(f"XLS: {xls_path}")

--- a/saleswb_import_flat.py
+++ b/saleswb_import_flat.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import json
@@ -7,9 +7,9 @@ import pandas as pd
 from datetime import datetime
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Получаем период загрузки из Excel ---
 df_settings = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")

--- a/stockswb_import_flat.py
+++ b/stockswb_import_flat.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import json
@@ -7,9 +7,9 @@ import pandas as pd
 from datetime import datetime
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Получаем "ПериодНачало" из Excel ---
 df_settings = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")

--- a/wb_tariffs_box_import.py
+++ b/wb_tariffs_box_import.py
@@ -1,13 +1,13 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
 from datetime import datetime
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path  = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path  = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB:  {db_path}")
 print(f"XLS: {xls_path}")

--- a/wbtariffs_commission_import.py
+++ b/wbtariffs_commission_import.py
@@ -1,12 +1,12 @@
-import os
+from pathlib import Path
 import sqlite3
 import requests
 import pandas as pd
 
 # --- Пути ---
-base_dir = os.path.abspath(os.path.join(os.getcwd(), ".."))
-db_path = os.path.join(base_dir, "finmodel.db")
-xls_path = os.path.join(base_dir, "Finmodel.xlsm")
+base_dir = Path(__file__).resolve().parent.parent
+db_path = base_dir / "finmodel.db"
+xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Чтение всех токенов ---
 df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")


### PR DESCRIPTION
## Summary
- Replace os.path based base_dir resolution with `Path(__file__).resolve().parent.parent`
- Build database and Excel paths using `base_dir / "finmodel.db"` and `base_dir / "Finmodel.xlsm"`

## Testing
- `python -m py_compile adv_campaigns_details_import_flat.py katalog.py adv_campaigns_import_flat.py wbtariffs_commission_import.py saleswb_import_flat.py paid_storage_import_incremental.py wb_tariffs_box_import.py stockswb_import_flat.py paid_storage_import_flat.py orderswb_import_flat.py adv_fullstats_import_flat.py nm_report_history_import.py finotchet_import.py`

------
https://chatgpt.com/codex/tasks/task_e_689ec6877fc4832abef16741130ca9ec