### PR TITLE
Use constant for WB API page limit

### DIFF
--- a/orderswb_import_flat.py
+++ b/orderswb_import_flat.py
@@ -6,6 +6,9 @@ import time
 import pandas as pd
 from datetime import datetime
 
+# Максимальный размер страницы, заявленный в документации WB API
+PAGE_LIMIT = 100_000
+
 # --- Пути ---
 base_dir = Path(__file__).resolve().parent.parent
 db_path = base_dir / "finmodel.db"
@@ -111,7 +114,7 @@ for _, row in df_orgs.iterrows():
         total_loaded += len(rows)
         print(f"  +{len(rows)} заказов (итого: {total_loaded})")
 
-        if len(rows) == 0 or len(rows) < 80000:
+        if len(rows) < PAGE_LIMIT:
             print("  ✅ Заказы по периоду загружены полностью.")
             break
 

--- a/saleswb_import_flat.py
+++ b/saleswb_import_flat.py
@@ -6,6 +6,9 @@ import time
 import pandas as pd
 from datetime import datetime
 
+# Максимальный размер страницы, заявленный в документации WB API
+PAGE_LIMIT = 100_000
+
 # --- Пути ---
 base_dir = Path(__file__).resolve().parent.parent
 db_path = base_dir / "finmodel.db"
@@ -111,7 +114,7 @@ for _, row in df_orgs.iterrows():
         total_loaded += len(rows)
         print(f"  +{len(rows)} продаж (итого: {total_loaded})")
 
-        if len(rows) == 0 or len(rows) < 80000:
+        if len(rows) < PAGE_LIMIT:
             print("  ✅ Продажи по периоду загружены полностью.")
             break
 

--- a/stockswb_import_flat.py
+++ b/stockswb_import_flat.py
@@ -6,6 +6,9 @@ import time
 import pandas as pd
 from datetime import datetime
 
+# Максимальный размер страницы, заявленный в документации WB API
+PAGE_LIMIT = 100_000
+
 # --- Пути ---
 base_dir = Path(__file__).resolve().parent.parent
 db_path = base_dir / "finmodel.db"
@@ -109,7 +112,7 @@ for _, row in df_orgs.iterrows():
         total_loaded += len(rows)
         print(f"  +{len(rows)} остатков (итого: {total_loaded})")
 
-        if len(rows) == 0 or len(rows) < 60000:
+        if len(rows) < PAGE_LIMIT:
             print("  ✅ Остатки по периоду загружены полностью.")
             break
 


### PR DESCRIPTION
## Summary
- define PAGE_LIMIT constant (100000) in data import scripts
- break pagination loops when `len(rows) < PAGE_LIMIT`

## Testing
- `python -m py_compile orderswb_import_flat.py`
- `python -m py_compile saleswb_import_flat.py`
- `python -m py_compile stockswb_import_flat.py`


------
https://chatgpt.com/codex/tasks/task_e_689ecb4c62c0832abafc249f445666f1