### PR TITLE
Handle non-200 responses in katalog

### DIFF
--- a/katalog.py
+++ b/katalog.py
@@ -82,6 +82,9 @@ for _, row in df_orgs.iterrows():
 
         try:
             response = requests.post(url, json=payload, headers=headers, timeout=30)
+            if response.status_code != 200:
+                print(f"Ошибка запроса: статус {response.status_code}, ответ: {response.text}")
+                break
             data = response.json()
         except Exception as e:
             print(f"Ошибка запроса: {e}")


### PR DESCRIPTION
## Summary
- log and handle non-200 HTTP responses when fetching katalog cards

## Testing
- `python -m py_compile katalog.py`


------
https://chatgpt.com/codex/tasks/task_e_689ecd7b8a3c832a8002acc9c101d876