### PR TITLE
Use context managers for SQLite connections

### DIFF
--- a/adv_campaigns_import_flat.py
+++ b/adv_campaigns_import_flat.py
@@ -26,10 +26,11 @@ FIELDS = [
 ]
 
 # --- Пересоздаём таблицу ---
-conn = sqlite3.connect(db_path)
-cursor = conn.cursor()
-cursor.execute("DROP TABLE IF EXISTS AdvCampaignsFlat;")
-cursor.execute(f"""
+total_rows = 0
+with sqlite3.connect(db_path) as conn:
+    with conn.cursor() as cursor:
+        cursor.execute("DROP TABLE IF EXISTS AdvCampaignsFlat;")
+        cursor.execute(f"""
 CREATE TABLE AdvCampaignsFlat (
     org_id TEXT,
     Организация TEXT,
@@ -42,89 +43,84 @@ CREATE TABLE AdvCampaignsFlat (
     PRIMARY KEY (org_id, campaignId)
 );
 """)
-conn.commit()
 
-URL = "https://advert-api.wildberries.ru/adv/v1/promotion/count"
-HEADERS_BASE = {"Content-Type": "application/json"}
+        URL = "https://advert-api.wildberries.ru/adv/v1/promotion/count"
+        HEADERS_BASE = {"Content-Type": "application/json"}
 
-def norm_ts(v):
-    if not v or str(v).strip()=="":
-        return ""
-    try:
-        return pd.to_datetime(v).strftime("%Y-%m-%d %H:%M:%S")
-    except Exception:
-        return str(v)
+        def norm_ts(v):
+            if not v or str(v).strip()=="":
+                return ""
+            try:
+                return pd.to_datetime(v).strftime("%Y-%m-%d %H:%M:%S")
+            except Exception:
+                return str(v)
 
-total_rows = 0
+        for _, r in df_orgs.iterrows():
+            org_id   = str(r["id"])
+            org_name = str(r["Организация"])
+            token    = str(r["Token_WB"]).strip()
 
-for _, r in df_orgs.iterrows():
-    org_id   = str(r["id"])
-    org_name = str(r["Организация"])
-    token    = str(r["Token_WB"]).strip()
+            print(f"\n→ Организация: {org_name} (ID={org_id})")
+            headers = HEADERS_BASE.copy()
+            headers["Authorization"] = token
 
-    print(f"\n→ Организация: {org_name} (ID={org_id})")
-    headers = HEADERS_BASE.copy()
-    headers["Authorization"] = token
+            try:
+                resp = requests.get(URL, headers=headers, timeout=60)
+                print(f"  HTTP {resp.status_code}")
+                preview = (resp.text or "")[:500].replace("\n"," ")
+                print("  Ответ (начало):", preview if preview else "[пусто]")
 
-    try:
-        resp = requests.get(URL, headers=headers, timeout=60)
-        print(f"  HTTP {resp.status_code}")
-        preview = (resp.text or "")[:500].replace("\n"," ")
-        print("  Ответ (начало):", preview if preview else "[пусто]")
+                if resp.status_code != 200:
+                    continue
 
-        if resp.status_code != 200:
-            continue
-
-        data = resp.json() or {}
-    except Exception as e:
-        print(f"  ⚠️ Ошибка запроса: {e}")
-        time.sleep(0.3)
-        continue
-
-    adverts = data.get("adverts", [])
-    if not isinstance(adverts, list) or not adverts:
-        print("  ⚠️ Пустой список adverts.")
-        time.sleep(0.3)
-        continue
-
-    now_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    rows = []
-
-    # ожидаемый формат: adverts: [{type, status, count, advert_list: [{advertId, changeTime}, ...]}, ...]
-    for group in adverts:
-        camp_type   = str(group.get("type", ""))     # числовой код типа
-        camp_status = str(group.get("status", ""))   # числовой код статуса
-        items       = group.get("advert_list", []) or []
-        for it in items:
-            advert_id = it.get("advertId")
-            change_ts = norm_ts(it.get("changeTime"))
-            if advert_id is None:
+                data = resp.json() or {}
+            except Exception as e:
+                print(f"  ⚠️ Ошибка запроса: {e}")
+                time.sleep(0.3)
                 continue
-            rows.append([
-                org_id, org_name,
-                str(advert_id),
-                "",                 # имя кампании из этого метода не приходит
-                camp_type,
-                camp_status,
-                change_ts,
-                now_str
-            ])
 
-    if not rows:
-        print("  ⚠️ Кампаний не найдено по этому токену.")
-        time.sleep(0.3)
-        continue
+            adverts = data.get("adverts", [])
+            if not isinstance(adverts, list) or not adverts:
+                print("  ⚠️ Пустой список adverts.")
+                time.sleep(0.3)
+                continue
 
-    try:
-        placeholders = ",".join(["?"] * len(FIELDS))
-        cursor.executemany(f"INSERT OR REPLACE INTO AdvCampaignsFlat VALUES ({placeholders})", rows)
-        conn.commit()
-        total_rows += len(rows)
-        print(f"  ✅ Загружено {len(rows)} кампаний (плоско).")
-    except Exception as e:
-        print(f"  ⚠️ Ошибка вставки: {e}")
+            now_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            rows = []
 
-    time.sleep(0.3)  # лимит 5 req/sec
+            # ожидаемый формат: adverts: [{type, status, count, advert_list: [{advertId, changeTime}, ...]}, ...]
+            for group in adverts:
+                camp_type   = str(group.get("type", ""))     # числовой код типа
+                camp_status = str(group.get("status", ""))   # числовой код статуса
+                items       = group.get("advert_list", []) or []
+                for it in items:
+                    advert_id = it.get("advertId")
+                    change_ts = norm_ts(it.get("changeTime"))
+                    if advert_id is None:
+                        continue
+                    rows.append([
+                        org_id, org_name,
+                        str(advert_id),
+                        "",                 # имя кампании из этого метода не приходит
+                        camp_type,
+                        camp_status,
+                        change_ts,
+                        now_str
+                    ])
 
-conn.close()
+            if not rows:
+                print("  ⚠️ Кампаний не найдено по этому токену.")
+                time.sleep(0.3)
+                continue
+
+            try:
+                placeholders = ",".join(["?"] * len(FIELDS))
+                cursor.executemany(f"INSERT OR REPLACE INTO AdvCampaignsFlat VALUES ({placeholders})", rows)
+                total_rows += len(rows)
+                print(f"  ✅ Загружено {len(rows)} кампаний (плоско).")
+            except Exception as e:
+                print(f"  ⚠️ Ошибка вставки: {e}")
+
+            time.sleep(0.3)  # лимит 5 req/sec
+
 print(f"\n✅ Готово. Всего записей добавлено/обновлено: {total_rows}")


### PR DESCRIPTION
## Summary
- replace raw SQLite connections with context managers across data import scripts
- remove manual commits and closes, letting context managers handle transactions

## Testing
- `python -m py_compile adv_campaigns_import_flat.py finotchet_import.py wb_goods_prices_import_flat.py wb_spp_fetch.py wb_spp_fetch_final.py`


------
https://chatgpt.com/codex/tasks/task_e_689ed3d7355c832a999b4eaab9e6a62b