### PR TITLE
refactor: centralize settings utilities

### DIFF
--- a/orderswb_import_flat.py
+++ b/orderswb_import_flat.py
@@ -4,7 +4,8 @@ import requests
 import json
 import time
 import pandas as pd
-from datetime import datetime
+
+from utils.settings import find_setting, parse_date
 
 # Максимальный размер страницы, заявленный в документации WB API
 PAGE_LIMIT = 100_000
@@ -15,21 +16,8 @@ db_path = base_dir / "finmodel.db"
 xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Получаем период загрузки из Excel ---
-df_settings = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")
-def find_setting(name):
-    val = df_settings.loc[df_settings["Параметр"].str.strip() == name, "Значение"]
-    return val.values[0] if not val.empty else None
-def parse_date(dt):
-    s = str(dt).replace("T", " ").replace("/", ".").strip()
-    try:
-        return datetime.strptime(s, "%d.%m.%Y").strftime("%Y-%m-%dT00:00:00")
-    except Exception:
-        try:
-            return datetime.strptime(s, "%Y-%m-%d").strftime("%Y-%m-%dT00:00:00")
-        except Exception:
-            return pd.to_datetime(s).strftime("%Y-%m-%dT%H:%M:%S")
-period_start = parse_date(find_setting("ПериодНачало"))
-period_end   = parse_date(find_setting("ПериодКонец"))
+period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
+period_end   = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
 print(f"Период загрузки заказов: {period_start} .. {period_end}")
 
 # --- Чтение организаций ---

--- a/paid_storage_import_flat.py
+++ b/paid_storage_import_flat.py
@@ -5,6 +5,8 @@ import pandas as pd
 import time
 from datetime import datetime, timedelta
 
+from utils.settings import find_setting, parse_date
+
 # ---------------- Paths ----------------
 base_dir = Path(__file__).resolve().parent.parent
 db_path  = base_dir / "finmodel.db"
@@ -12,14 +14,6 @@ xls_path = base_dir / "Finmodel.xlsm"
 
 print(f"DB:  {db_path}")
 print(f"XLS: {xls_path}")
-
-# ---------------- Helpers ----------------
-def parse_date_any(x) -> datetime:
-    """Robust parse to date (not datetime)."""
-    if x is None or str(x).strip() == "":
-        raise ValueError("empty date")
-    s = str(x).strip().replace("T", " ")
-    return pd.to_datetime(s).to_pydatetime()
 
 def daterange_8d(d1: datetime, d2: datetime):
     """Yield (from, to) windows of up to 8 days inclusive."""
@@ -39,12 +33,6 @@ def sleep_with_log(sec: float, msg: str = ""):
     time.sleep(sec)
 
 # ---------------- Load settings ----------------
-# Period from Excel (Настройки)
-df_set = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")
-def find_setting(name):
-    ser = df_set.loc[df_set["Параметр"].astype(str).str.strip() == name, "Значение"]
-    return None if ser.empty else ser.values[0]
-
 period_start_raw = find_setting("ПериодНачало")
 period_end_raw   = find_setting("ПериодКонец")
 
@@ -52,8 +40,8 @@ if not period_start_raw or not period_end_raw:
     print("❗ В листе 'Настройки' не найдены ПериодНачало/ПериодКонец.")
     raise SystemExit(1)
 
-period_start = parse_date_any(period_start_raw).date()
-period_end   = parse_date_any(period_end_raw).date()
+period_start = parse_date(period_start_raw).date()
+period_end   = parse_date(period_end_raw).date()
 if period_end < period_start:
     print("❗ ПериодКонец раньше ПериодНачало.")
     raise SystemExit(1)

--- a/saleswb_import_flat.py
+++ b/saleswb_import_flat.py
@@ -4,7 +4,8 @@ import requests
 import json
 import time
 import pandas as pd
-from datetime import datetime
+
+from utils.settings import find_setting, parse_date
 
 # Максимальный размер страницы, заявленный в документации WB API
 PAGE_LIMIT = 100_000
@@ -15,21 +16,8 @@ db_path = base_dir / "finmodel.db"
 xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Получаем период загрузки из Excel ---
-df_settings = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")
-def find_setting(name):
-    val = df_settings.loc[df_settings["Параметр"].str.strip() == name, "Значение"]
-    return val.values[0] if not val.empty else None
-def parse_date(dt):
-    s = str(dt).replace("T", " ").replace("/", ".").strip()
-    try:
-        return datetime.strptime(s, "%d.%m.%Y").strftime("%Y-%m-%dT00:00:00")
-    except Exception:
-        try:
-            return datetime.strptime(s, "%Y-%m-%d").strftime("%Y-%m-%dT00:00:00")
-        except Exception:
-            return pd.to_datetime(s).strftime("%Y-%m-%dT%H:%M:%S")
-period_start = parse_date(find_setting("ПериодНачало"))
-period_end   = parse_date(find_setting("ПериодКонец"))
+period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
+period_end   = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
 print(f"Период загрузки продаж: {period_start} .. {period_end}")
 
 # --- Чтение организаций ---

--- a/stockswb_import_flat.py
+++ b/stockswb_import_flat.py
@@ -4,7 +4,8 @@ import requests
 import json
 import time
 import pandas as pd
-from datetime import datetime
+
+from utils.settings import find_setting, parse_date
 
 # Максимальный размер страницы, заявленный в документации WB API
 PAGE_LIMIT = 100_000
@@ -15,20 +16,7 @@ db_path = base_dir / "finmodel.db"
 xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Получаем "ПериодНачало" из Excel ---
-df_settings = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")
-def find_setting(name):
-    val = df_settings.loc[df_settings["Параметр"].str.strip() == name, "Значение"]
-    return val.values[0] if not val.empty else None
-def parse_date(dt):
-    s = str(dt).replace("T", " ").replace("/", ".").strip()
-    try:
-        return datetime.strptime(s, "%d.%m.%Y").strftime("%Y-%m-%dT00:00:00")
-    except Exception:
-        try:
-            return datetime.strptime(s, "%Y-%m-%d").strftime("%Y-%m-%dT00:00:00")
-        except Exception:
-            return pd.to_datetime(s).strftime("%Y-%m-%dT%H:%M:%S")
-period_start = parse_date(find_setting("ПериодНачало"))
+period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
 print(f"Дата начала загрузки остатков: {period_start}")
 
 # --- Чтение организаций ---

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,19 @@
+import datetime
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils.settings import parse_date
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("01.02.2023", datetime.datetime(2023, 2, 1)),
+        ("2023-02-01", datetime.datetime(2023, 2, 1)),
+        ("2023-02-01T13:45:00", datetime.datetime(2023, 2, 1, 13, 45, 0)),
+    ],
+)
+def test_parse_date(raw, expected):
+    assert parse_date(raw) == expected

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime
+import pandas as pd
+
+# Path to the Excel settings file
+base_dir = Path(__file__).resolve().parent.parent
+xls_path = base_dir / "Finmodel.xlsm"
+
+_df_settings = None
+
+def _load_settings() -> None:
+    global _df_settings
+    if _df_settings is None:
+        _df_settings = pd.read_excel(xls_path, sheet_name="Настройки", engine="openpyxl")
+
+def find_setting(name: str):
+    """Return the value of a setting by name from the Excel file."""
+    _load_settings()
+    val = _df_settings.loc[_df_settings["Параметр"].astype(str).str.strip() == name, "Значение"]
+    return val.values[0] if not val.empty else None
+
+def parse_date(dt) -> datetime:
+    """Parse various date formats into ``datetime``.
+
+    Supports ``dd.mm.yyyy``, ``yyyy-mm-dd`` and arbitrary ISO-like formats.
+    """
+    s = str(dt).replace("T", " ").replace("/", ".").strip()
+    if s == "":
+        raise ValueError("empty date")
+    for fmt in ("%d.%m.%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(s, fmt)
+        except ValueError:
+            continue
+    return pd.to_datetime(s).to_pydatetime()


### PR DESCRIPTION
## Summary
- add shared `find_setting` and `parse_date` helpers in `utils/settings.py`
- refactor data import scripts to use the new helpers
- test date parsing across supported formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed4a8cbb0832a945a7964c39999b8