### PR TITLE
docs: add README and development guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS Instructions
+
+These guidelines apply to the entire repository.
+
+## Environment
+- Target Python 3.10 or newer.
+- Work inside a virtual environment and install dependencies from `requirements.txt` when available.
+
+## Workflow
+- Format code with `black` (line length 100) and sort imports with `isort`.
+- Run `python -m compileall -q .` before committing. If tests exist, also run `pytest` and ensure all pass.
+- Write commit messages in English using the imperative mood.
+
+## Style
+- Follow PEP 8 with 4-space indentation.
+- Use descriptive names and keep code and comments in English.
+- Avoid executing logic at import time; use `if __name__ == "__main__":` for script entry points.
+
+## Documentation
+- Update `README.md` whenever new scripts or workflows are added or modified.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Finmodel 2.0
+
+Python utilities for importing and analyzing financial data from the Wildberries marketplace.
+
+## Features
+- Import advertising campaigns, orders, stocks, tariffs and more using dedicated scripts.
+- Store imported records in `finmodel.db` for subsequent analysis.
+
+## Quick start
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt  # if available
+   ```
+2. Configure any required API credentials for Wildberries in environment variables.
+3. Run a script, e.g.:
+   ```bash
+   python saleswb_import_flat.py
+   ```
+
+## Development
+- Follow instructions in `AGENTS.md` for coding standards and testing.
+- Ensure new scripts include descriptive docstrings and a guarded `main` entry point.
+- Run `python -m compileall -q .` to verify syntax before committing.
+
+## License
+Specify the project license if applicable.


### PR DESCRIPTION
## Summary
- add project overview and quick-start instructions in README
- introduce AGENTS file with repository-wide development and style guidelines

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_689ed48613fc832a9fa58aa6d5ba9fdc