### PR TITLE
Add retryable HTTP sessions to WB import scripts

### DIFF
--- a/orderswb_import_flat.py
+++ b/orderswb_import_flat.py
@@ -1,14 +1,17 @@
-from pathlib import Path
-import sqlite3
-import requests
 import json
+import sqlite3
 import time
+from pathlib import Path
+
 import pandas as pd
+import requests
+from requests.adapters import HTTPAdapter, Retry
 
 from utils.settings import find_setting, parse_date
 
 # Максимальный размер страницы, заявленный в документации WB API
 PAGE_LIMIT = 100_000
+REQUEST_TIMEOUT = 60
 
 # --- Пути ---
 base_dir = Path(__file__).resolve().parent.parent
@@ -17,7 +20,7 @@ xls_path = base_dir / "Finmodel.xlsm"
 
 # --- Получаем период загрузки из Excel ---
 period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
-period_end   = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
+period_end = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
 print(f"Период загрузки заказов: {period_start} .. {period_end}")
 
 # --- Чтение организаций ---
@@ -26,10 +29,33 @@ df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
 
 # --- Все возможные поля заказа (WB-API) ---
 ORDER_FIELDS = [
-    "date", "lastChangeDate", "warehouseName", "warehouseType", "countryName", "oblastOkrugName", "regionName",
-    "supplierArticle", "nmId", "barcode", "category", "subject", "brand", "techSize", "incomeID", "isSupply",
-    "isRealization", "totalPrice", "discountPercent", "spp", "finishedPrice", "priceWithDisc", "isCancel",
-    "cancelDate", "sticker", "gNumber", "srid"
+    "date",
+    "lastChangeDate",
+    "warehouseName",
+    "warehouseType",
+    "countryName",
+    "oblastOkrugName",
+    "regionName",
+    "supplierArticle",
+    "nmId",
+    "barcode",
+    "category",
+    "subject",
+    "brand",
+    "techSize",
+    "incomeID",
+    "isSupply",
+    "isRealization",
+    "totalPrice",
+    "discountPercent",
+    "spp",
+    "finishedPrice",
+    "priceWithDisc",
+    "isCancel",
+    "cancelDate",
+    "sticker",
+    "gNumber",
+    "srid",
 ]
 
 # --- Подключение к базе и создание плоской таблицы ---
@@ -37,19 +63,40 @@ conn = sqlite3.connect(db_path)
 cursor = conn.cursor()
 fields_sql = ", ".join([f"{f} TEXT" for f in ORDER_FIELDS])
 cursor.execute("DROP TABLE IF EXISTS OrdersWBFlat;")
-cursor.execute(f"""
+cursor.execute(
+    f"""
 CREATE TABLE OrdersWBFlat (
     org_id INTEGER,
     Организация TEXT,
     {fields_sql},
     PRIMARY KEY (org_id, srid)
 );
-""")
+"""
+)
 conn.commit()
+
+
+# --- HTTP session ---
+def make_http() -> requests.Session:
+    s = requests.Session()
+    retries = Retry(
+        total=5,
+        read=5,
+        connect=5,
+        backoff_factor=0.5,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset(["GET"]),
+    )
+    s.mount("https://", HTTPAdapter(max_retries=retries))
+    s.mount("http://", HTTPAdapter(max_retries=retries))
+    return s
+
 
 # --- API запрос ---
 url = "https://statistics-api.wildberries.ru/api/v1/supplier/orders"
 headers_template = {"Content-Type": "application/json"}
+
+http = make_http()
 
 for _, row in df_orgs.iterrows():
     org_id = row["id"]
@@ -68,7 +115,7 @@ for _, row in df_orgs.iterrows():
         params = {"dateFrom": date_from}
         print(f"  📤 Запрос page {page}, dateFrom={date_from} ...", end=" ", flush=True)
         try:
-            resp = requests.get(url, params=params, headers=headers, timeout=60)
+            resp = http.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
             if resp.status_code != 200:
                 print(f"\n  ⚠️ Запрос вернул статус {resp.status_code}: {resp.text}")
                 time.sleep(5)
@@ -90,10 +137,13 @@ for _, row in df_orgs.iterrows():
             rows.append(flat)
         try:
             placeholders = ",".join(["?"] * (2 + len(ORDER_FIELDS)))
-            cursor.executemany(f"""
+            cursor.executemany(
+                f"""
                 INSERT OR REPLACE INTO OrdersWBFlat
                 VALUES ({placeholders})
-            """, rows)
+            """,
+                rows,
+            )
             conn.commit()
         except Exception as e:
             print(f"\n  ⚠️ Ошибка вставки: {e}")


### PR DESCRIPTION
## Summary
- build reusable HTTP sessions with retries for stocks, sales and orders imports
- use `session.get` with timeouts to better handle transient HTTP errors

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ed6e4c110832a9ab5d421b34c4d4d