### PR TITLE
Load configuration from YAML and environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.yml
+.env

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Python utilities for importing and analyzing financial data from the Wildberries
    source venv/bin/activate
    pip install -r requirements.txt  # if available
    ```
-2. Configure any required API credentials for Wildberries in environment variables.
+2. Copy `config.example.yml` to `config.yml` and fill in database path, date ranges
+   and tokens. Environment variables with the same keys override the file values.
 3. Run a script via the package module or installed console entry point, e.g.:
    ```bash
    python -m finmodel.scripts.saleswb_import_flat

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,11 @@
+db_path: /path/to/finmodel.db
+settings:
+  ПериодНачало: '2023-01-01'
+  ПериодКонец: '2023-01-31'
+organizations:
+  - id: 1
+    Организация: 'Org1'
+    Token_WB: 'token1'
+  - id: 2
+    Организация: 'Org2'
+    Token_WB: 'token2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Utilities for importing and analyzing Wildberries financial data"
 readme = "README.md"
 requires-python = ">=3.10"
+dependencies = ["PyYAML>=6.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/finmodel/scripts/adv_campaigns_details_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_details_import_flat.py
@@ -6,21 +6,22 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from finmodel.utils.settings import load_config
 
-def main():
+
+def main(config=None):
+    config = config or load_config()
     # --- Пути ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
     print(f"DB: {db_path}")
-    print(f"XLSX: {xls_path}")
 
     # --- Читаем организации/токены ---
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
     if df_orgs.empty:
-        print("❗ Лист 'НастройкиОрганизаций' пуст или нет колонок id/Организация/Token_WB")
+        print("❗ Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Итоговая плоская таблица (пересоздаём на каждый запуск) ---

--- a/src/finmodel/scripts/adv_campaigns_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_import_flat.py
@@ -6,19 +6,23 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from finmodel.utils.settings import load_config
 
-def main():
+
+def main(config=None):
+    config = config or load_config()
     # --- Пути ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
     print(f"DB: {db_path}")
-    print(f"XLSX: {xls_path}")
 
     # --- Читаем организации/токены ---
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    if df_orgs.empty:
+        print("❗ Конфигурация не содержит организаций с токенами.")
+        return
 
     # --- Итоговые поля таблицы ---
     FIELDS = [

--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -1,4 +1,4 @@
-def main():
+def main(config=None):
     # -*- coding: utf-8 -*-
     import random
     import sqlite3
@@ -9,13 +9,14 @@ def main():
     import pandas as pd
     import requests
 
+    from finmodel.utils.settings import load_config
+
+    config = config or load_config()
+
     # ---------- Paths ----------
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
-
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
     print(f"DB:  {db_path}")
-    print(f"XLS: {xls_path}")
 
     # ---------- Period (last 7 days via interval) ----------
     today = datetime.now().date()
@@ -74,10 +75,10 @@ def main():
         _last_post_ts = now
 
     # ---------- Orgs/tokens ----------
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
     if df_orgs.empty:
-        print("❗ Нет организаций/токенов в листе 'НастройкиОрганизаций'.")
+        print("❗ Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # ---------- DB & target table ----------

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -5,16 +5,21 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from finmodel.utils.settings import load_config
 
-def main():
-    # 📌 Пути к базе и Excel-файлу
+
+def main(config=None):
+    config = config or load_config()
+    # 📌 Пути к базе
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
     # 📌 Чтение таблицы организаций
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    if df_orgs.empty:
+        print("❗ Конфигурация не содержит организаций с токенами.")
+        return
 
     # 📌 Подключение к базе
     try:

--- a/src/finmodel/scripts/nm_report_history_import.py
+++ b/src/finmodel/scripts/nm_report_history_import.py
@@ -6,15 +6,16 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from finmodel.utils.settings import load_config
 
-def main():
+
+def main(config=None):
+    config = config or load_config()
     # --- Пути ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
     print(f"DB:  {db_path}")
-    print(f"XLS: {xls_path}")
 
     # --- Период: всегда последние 7 дней (включая сегодня) ---
     today = datetime.now().date()
@@ -23,10 +24,10 @@ def main():
     print(f"Период запроса: {date_from} .. {date_to}")
 
     # --- Чтение организаций и токенов ---
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
     if df_orgs.empty:
-        print("❗ Нет организаций/токенов в листе 'НастройкиОрганизаций'.")
+        print("❗ Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Подключение к БД ---

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -6,17 +6,16 @@ from pathlib import Path
 import pandas as pd
 import requests
 
-from finmodel.utils.settings import find_setting, parse_date
+from finmodel.utils.settings import find_setting, load_config, parse_date
 
 
-def main():
+def main(config=None):
+    config = config or load_config()
     # ---------------- Paths ----------------
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
     print(f"DB:  {db_path}")
-    print(f"XLS: {xls_path}")
 
     def daterange_8d(d1: datetime, d2: datetime):
         """Yield (from, to) windows of up to 8 days inclusive."""
@@ -40,7 +39,7 @@ def main():
     period_end_raw = find_setting("ПериодКонец")
 
     if not period_start_raw or not period_end_raw:
-        print("❗ В листе 'Настройки' не найдены ПериодНачало/ПериодКонец.")
+        print("❗ Settings do not include ПериодНачало/ПериодКонец.")
         raise SystemExit(1)
 
     period_start = parse_date(period_start_raw).date()
@@ -52,10 +51,10 @@ def main():
     print(f"Период: {period_start} .. {period_end}")
 
     # Orgs with tokens
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
     if df_orgs.empty:
-        print("❗ Лист 'НастройкиОрганизаций' пуст или нет нужных колонок.")
+        print("❗ Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # ---------------- DB: table ----------------

--- a/src/finmodel/scripts/paid_storage_import_incremental.py
+++ b/src/finmodel/scripts/paid_storage_import_incremental.py
@@ -6,15 +6,16 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from finmodel.utils.settings import load_config
 
-def main():
+
+def main(config=None):
+    config = config or load_config()
     # ---------- Paths ----------
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
     print(f"DB:  {db_path}")
-    print(f"XLS: {xls_path}")
 
     # ---------- Helpers ----------
     def iso_date(d: date) -> str:
@@ -33,10 +34,10 @@ def main():
         time.sleep(sec)
 
     # ---------- Orgs ----------
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
     if df_orgs.empty:
-        print("❗ 'НастройкиОрганизаций' пуст или нет колонок id/Организация/Token_WB.")
+        print("❗ Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # ---------- DB ----------

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -7,27 +7,30 @@ import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from finmodel.utils.settings import find_setting, parse_date
+from finmodel.utils.settings import find_setting, load_config, parse_date
 
 
-def main():
+def main(config=None):
+    config = config or load_config()
     # Максимальный размер страницы, заявленный в документации WB API
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60
 
     # --- Пути ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
-    # --- Получаем период загрузки из Excel ---
+    # --- Получаем период загрузки ---
     period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
     period_end = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
     print(f"Период загрузки продаж: {period_start} .. {period_end}")
 
     # --- Чтение организаций ---
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    if df_orgs.empty:
+        print("❗ Конфигурация не содержит организаций с токенами.")
+        raise SystemExit(1)
 
     # --- Все возможные поля продажи (WB-API) ---
     SALES_FIELDS = [

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -7,26 +7,29 @@ import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from finmodel.utils.settings import find_setting, parse_date
+from finmodel.utils.settings import find_setting, load_config, parse_date
 
 
-def main():
+def main(config=None):
+    config = config or load_config()
     # Максимальный размер страницы, заявленный в документации WB API
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60
 
     # --- Пути ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
-    # --- Получаем "ПериодНачало" из Excel ---
+    # --- Получаем "ПериодНачало" ---
     period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
     print(f"Дата начала загрузки остатков: {period_start}")
 
     # --- Чтение организаций ---
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
+    df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    if df_orgs.empty:
+        print("❗ Конфигурация не содержит организаций с токенами.")
+        raise SystemExit(1)
 
     # --- Все возможные поля остатков (WB-API) ---
     STOCKS_FIELDS = [

--- a/src/finmodel/scripts/wbtariffs_commission_import.py
+++ b/src/finmodel/scripts/wbtariffs_commission_import.py
@@ -4,16 +4,21 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from finmodel.utils.settings import load_config
 
-def main():
+
+def main(config=None):
+    config = config or load_config()
     # --- Пути ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
-    xls_path = base_dir / "Finmodel.xlsm"
+    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
     # --- Чтение всех токенов ---
-    df_orgs = pd.read_excel(xls_path, sheet_name="НастройкиОрганизаций", engine="openpyxl")
-    tokens = df_orgs["Token_WB"].dropna().astype(str).tolist()
+    df_orgs = pd.DataFrame(config.get("organizations", []))
+    tokens = df_orgs.get("Token_WB", pd.Series()).dropna().astype(str).tolist()
+    if not tokens:
+        print("❗ Конфигурация не содержит токенов.")
+        return
 
     # --- Поля по документации WB ---
     FIELDS = [


### PR DESCRIPTION
## Summary
- Parse settings from `config.yml` or environment variables and expose `load_config` helper
- Switch scripts to configuration-driven tokens and database paths
- Document configuration usage and add PyYAML dependency

## Testing
- `isort .`
- `black -l 100 src/finmodel/utils/settings.py src/finmodel/scripts/*.py`
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689edfc054a4832aae8a7aed38e5f690