### PR TITLE
Add requirements and configure tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ Python utilities for importing and analyzing financial data from the Wildberries
 - Import advertising campaigns, orders, stocks, tariffs and more using dedicated scripts.
 - Store imported records in `finmodel.db` for subsequent analysis.
 
-## Quick start
-1. Create a virtual environment and install dependencies:
+## Installation
+1. Create and activate a virtual environment:
    ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   pip install -r requirements.txt  # if available
+   python3 -m venv .venv
+   source .venv/bin/activate
    ```
-2. Copy `config.example.yml` to `config.yml` and fill in database path, date ranges
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy `config.example.yml` to `config.yml` and fill in database path, date ranges
    and tokens. Environment variables with the same keys override the file values.
-3. Run a script via the package module or installed console entry point, e.g.:
+4. Run a script via the package module or installed console entry point, e.g.:
    ```bash
    python -m finmodel.scripts.saleswb_import_flat
    # or after installing the package:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,15 @@ wb_spp_fetch_final = "finmodel.scripts.wb_spp_fetch_final:main"
 wb_spp_fetch_simple = "finmodel.scripts.wb_spp_fetch_simple:main"
 wb_tariffs_box_import = "finmodel.scripts.wb_tariffs_box_import:main"
 wbtariffs_commission_import = "finmodel.scripts.wbtariffs_commission_import:main"
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+black
+isort
+openpyxl
+pandas
+pytest
+requests
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- add project requirements list
- document setup steps in the README
- configure black, isort and pytest in `pyproject.toml`

## Testing
- `isort src tests -v`
- `black .`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee2e6e4bc832aa3253729a92b3b9d