### PR TITLE
Add centralized logging and replace prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,9 @@ Python utilities for importing and analyzing financial data from the Wildberries
 - Ensure new scripts include descriptive docstrings and a guarded `main` entry point.
 - Run `python -m compileall -q .` to verify syntax before committing.
 
+## Logs
+All scripts emit logs to the `log/finmodel.log` file. Create the `log/` directory if it
+does not exist to keep collected logs.
+
 ## License
 Specify the project license if applicable.

--- a/src/finmodel/logger.py
+++ b/src/finmodel/logger.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+LOG_DIR = Path(__file__).resolve().parents[2] / "log"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+LOG_FILE = LOG_DIR / "finmodel.log"
+
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format=LOG_FORMAT,
+    handlers=[
+        logging.FileHandler(LOG_FILE, encoding="utf-8"),
+        logging.StreamHandler(),
+    ],
+)
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger configured for the project."""
+    return logging.getLogger(name)

--- a/src/finmodel/scripts/finotchet_import.py
+++ b/src/finmodel/scripts/finotchet_import.py
@@ -3,6 +3,10 @@ import json
 import sqlite3
 from pathlib import Path
 
+from finmodel.logger import get_logger
+
+logger = get_logger(__name__)
+
 
 def main():
     # --- Пути к базе ---
@@ -124,16 +128,16 @@ def main():
                     )
                     total += 1
                     if total % 1000 == 0:
-                        print(f"  {total} строк обработано...")
+                        logger.info("  %s строк обработано...", total)
                 except Exception as e:
-                    print(f"Ошибка парсинга/org_id={org_id}: {e}")
+                    logger.warning("Ошибка парсинга/org_id=%s: %s", org_id, e)
                     errors += 1
 
-            print(f"\n✅ Всего записей обработано и вставлено: {total}")
+            logger.info("✅ Всего записей обработано и вставлено: %s", total)
             if errors:
-                print(f"❗ Были ошибки парсинга: {errors} записей не обработаны")
+                logger.warning("Были ошибки парсинга: %s записей не обработаны", errors)
 
-    print("Готово! Таблица FinOtchetFlat содержит плоские данные для PowerBI/Excel.")
+    logger.info("Готово! Таблица FinOtchetFlat содержит плоские данные для PowerBI/Excel.")
 
 
 if __name__ == "__main__":

--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -7,7 +7,10 @@ import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+from finmodel.logger import get_logger
 from finmodel.utils.settings import find_setting, load_config, parse_date
+
+logger = get_logger(__name__)
 
 
 def main(config=None):
@@ -23,13 +26,13 @@ def main(config=None):
     # --- Получаем период загрузки ---
     period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
     period_end = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
-    print(f"Период загрузки заказов: {period_start} .. {period_end}")
+    logger.info("Период загрузки заказов: %s .. %s", period_start, period_end)
 
     # --- Чтение организаций ---
     df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
     if df_orgs.empty:
-        print("❗ Конфигурация не содержит организаций с токенами.")
+        logger.error("Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Все возможные поля заказа (WB-API) ---
@@ -105,7 +108,7 @@ def main(config=None):
         org_id = row["id"]
         org_name = row["Организация"]
         token = row["Token_WB"]
-        print(f"\n→ Организация: {org_name} (ID={org_id})")
+        logger.info("→ Организация: %s (ID=%s)", org_name, org_id)
 
         headers = headers_template.copy()
         headers["Authorization"] = token
@@ -116,21 +119,21 @@ def main(config=None):
 
         while True:
             params = {"dateFrom": date_from}
-            print(f"  📤 Запрос page {page}, dateFrom={date_from} ...", end=" ", flush=True)
+            logger.info("  📤 Запрос page %s, dateFrom=%s ...", page, date_from)
             try:
                 resp = http.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
                 if resp.status_code != 200:
-                    print(f"\n  ⚠️ Запрос вернул статус {resp.status_code}: {resp.text}")
+                    logger.warning("  Запрос вернул статус %s: %s", resp.status_code, resp.text)
                     time.sleep(5)
                     break
                 data = resp.json()
             except Exception as e:
-                print(f"\n  ⚠️ Ошибка запроса: {e}")
+                logger.warning("  Ошибка запроса: %s", e)
                 time.sleep(5)
                 break
 
             if not data:
-                print("✅ Все заказы загружены для этой организации.")
+                logger.info("✅ Все заказы загружены для этой организации.")
                 break
 
             # Распаковка
@@ -149,14 +152,14 @@ def main(config=None):
                 )
                 conn.commit()
             except Exception as e:
-                print(f"\n  ⚠️ Ошибка вставки: {e}")
+                logger.warning("  Ошибка вставки: %s", e)
                 break
 
             total_loaded += len(rows)
-            print(f"  +{len(rows)} заказов (итого: {total_loaded})")
+            logger.info("  +%s заказов (итого: %s)", len(rows), total_loaded)
 
             if len(rows) < PAGE_LIMIT:
-                print("  ✅ Заказы по периоду загружены полностью.")
+                logger.info("  ✅ Заказы по периоду загружены полностью.")
                 break
 
             # pagination: следующий dateFrom = lastChangeDate последней строки
@@ -165,7 +168,7 @@ def main(config=None):
             time.sleep(3)  # Лимит 1 запрос в минуту, но WB часто разрешает чуть чаще
 
     conn.close()
-    print("\n✅ Все заказы загружены и распарсены в таблицу OrdersWBFlat (без дублей).")
+    logger.info("✅ Все заказы загружены и распарсены в таблицу OrdersWBFlat (без дублей).")
 
 
 if __name__ == "__main__":

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -7,7 +7,10 @@ import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+from finmodel.logger import get_logger
 from finmodel.utils.settings import find_setting, load_config, parse_date
+
+logger = get_logger(__name__)
 
 
 def main(config=None):
@@ -23,13 +26,13 @@ def main(config=None):
     # --- Получаем период загрузки ---
     period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
     period_end = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
-    print(f"Период загрузки продаж: {period_start} .. {period_end}")
+    logger.info("Период загрузки продаж: %s .. %s", period_start, period_end)
 
     # --- Чтение организаций ---
     df_orgs = pd.DataFrame(config.get("organizations", []))
     df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
     if df_orgs.empty:
-        print("❗ Конфигурация не содержит организаций с токенами.")
+        logger.error("Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Все возможные поля продажи (WB-API) ---
@@ -106,7 +109,7 @@ def main(config=None):
         org_id = row["id"]
         org_name = row["Организация"]
         token = row["Token_WB"]
-        print(f"\n→ Организация: {org_name} (ID={org_id})")
+        logger.info("→ Организация: %s (ID=%s)", org_name, org_id)
 
         headers = headers_template.copy()
         headers["Authorization"] = token
@@ -117,21 +120,21 @@ def main(config=None):
 
         while True:
             params = {"dateFrom": date_from}
-            print(f"  📤 Запрос page {page}, dateFrom={date_from} ...", end=" ", flush=True)
+            logger.info("  📤 Запрос page %s, dateFrom=%s ...", page, date_from)
             try:
                 resp = http.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
                 if resp.status_code != 200:
-                    print(f"\n  ⚠️ Запрос вернул статус {resp.status_code}: {resp.text}")
+                    logger.warning("  Запрос вернул статус %s: %s", resp.status_code, resp.text)
                     time.sleep(5)
                     break
                 data = resp.json()
             except Exception as e:
-                print(f"\n  ⚠️ Ошибка запроса: {e}")
+                logger.warning("  Ошибка запроса: %s", e)
                 time.sleep(5)
                 break
 
             if not data:
-                print("✅ Все продажи загружены для этой организации.")
+                logger.info("✅ Все продажи загружены для этой организации.")
                 break
 
             # Распаковка
@@ -150,14 +153,14 @@ def main(config=None):
                 )
                 conn.commit()
             except Exception as e:
-                print(f"\n  ⚠️ Ошибка вставки: {e}")
+                logger.warning("  Ошибка вставки: %s", e)
                 break
 
             total_loaded += len(rows)
-            print(f"  +{len(rows)} продаж (итого: {total_loaded})")
+            logger.info("  +%s продаж (итого: %s)", len(rows), total_loaded)
 
             if len(rows) < PAGE_LIMIT:
-                print("  ✅ Продажи по периоду загружены полностью.")
+                logger.info("  ✅ Продажи по периоду загружены полностью.")
                 break
 
             # pagination: следующий dateFrom = lastChangeDate последней строки
@@ -166,7 +169,7 @@ def main(config=None):
             time.sleep(3)  # WB лимит: 1 запрос в минуту, но можно чуть чаще
 
     conn.close()
-    print("\n✅ Все продажи загружены и распарсены в таблицу SalesWBFlat (без дублей).")
+    logger.info("✅ Все продажи загружены и распарсены в таблицу SalesWBFlat (без дублей).")
 
 
 if __name__ == "__main__":

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -7,7 +7,10 @@ import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
+from finmodel.logger import get_logger
 from finmodel.utils.settings import find_setting, load_config, parse_date
+
+logger = get_logger(__name__)
 
 
 def main(config=None):
@@ -22,13 +25,13 @@ def main(config=None):
 
     # --- Получаем "ПериодНачало" ---
     period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
-    print(f"Дата начала загрузки остатков: {period_start}")
+    logger.info("Дата начала загрузки остатков: %s", period_start)
 
     # --- Чтение организаций ---
     df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropна()
     if df_orgs.empty:
-        print("❗ Конфигурация не содержит организаций с токенами.")
+        logger.error("Конфигурация не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Все возможные поля остатков (WB-API) ---
@@ -95,7 +98,7 @@ def main(config=None):
         org_id = row["id"]
         org_name = row["Организация"]
         token = row["Token_WB"]
-        print(f"\n→ Организация: {org_name} (ID={org_id})")
+        logger.info("→ Организация: %s (ID=%s)", org_name, org_id)
 
         headers = headers_template.copy()
         headers["Authorization"] = token
@@ -106,21 +109,21 @@ def main(config=None):
 
         while True:
             params = {"dateFrom": date_from}
-            print(f"  📤 Запрос page {page}, dateFrom={date_from} ...", end=" ", flush=True)
+            logger.info("  📤 Запрос page %s, dateFrom=%s ...", page, date_from)
             try:
                 resp = http.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
                 if resp.status_code != 200:
-                    print(f"\n  ⚠️ Запрос вернул статус {resp.status_code}: {resp.text}")
+                    logger.warning("  Запрос вернул статус %s: %s", resp.status_code, resp.text)
                     time.sleep(5)
                     break
                 data = resp.json()
             except Exception as e:
-                print(f"\n  ⚠️ Ошибка запроса: {e}")
+                logger.warning("  Ошибка запроса: %s", e)
                 time.sleep(5)
                 break
 
             if not data:
-                print("✅ Все остатки загружены для этой организации.")
+                logger.info("✅ Все остатки загружены для этой организации.")
                 break
 
             # Распаковка
@@ -139,14 +142,14 @@ def main(config=None):
                 )
                 conn.commit()
             except Exception as e:
-                print(f"\n  ⚠️ Ошибка вставки: {e}")
+                logger.warning("  Ошибка вставки: %s", e)
                 break
 
             total_loaded += len(rows)
-            print(f"  +{len(rows)} остатков (итого: {total_loaded})")
+            logger.info("  +%s остатков (итого: %s)", len(rows), total_loaded)
 
             if len(rows) < PAGE_LIMIT:
-                print("  ✅ Остатки по периоду загружены полностью.")
+                logger.info("  ✅ Остатки по периоду загружены полностью.")
                 break
 
             # pagination: следующий dateFrom = lastChangeDate последней строки
@@ -155,7 +158,7 @@ def main(config=None):
             time.sleep(3)  # WB лимит: 1 запрос в минуту, но можно чуть чаще
 
     conn.close()
-    print("\n✅ Все остатки загружены и распарсены в таблицу StocksWBFlat (без дублей).")
+    logger.info("✅ Все остатки загружены и распарсены в таблицу StocksWBFlat (без дублей).")
 
 
 if __name__ == "__main__":

--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -15,6 +15,8 @@ def main():
     import requests
     from requests.adapters import HTTPAdapter, Retry
 
+    from finmodel.logger import get_logger
+
     WB_ENDPOINT = "https://card.wb.ru/cards/v1/detail"
     CHUNK_SIZE = 100
     TIMEOUT = 15
@@ -40,6 +42,8 @@ def main():
         s.mount("https://", HTTPAdapter(max_retries=retries))
         s.mount("http://", HTTPAdapter(max_retries=retries))
         return s
+
+    logger = get_logger(__name__)
 
     def fetch_batch(http: requests.Session, ids: List[str]) -> List[Dict[str, Any]]:
         ids_clean = [str(x).strip() for x in ids if str(x).strip()]
@@ -177,7 +181,7 @@ def main():
         import pyodbc
 
         if not rows:
-            print("Нет строк для записи в БД — пропускаю.")
+            logger.warning("Нет строк для записи в БД — пропускаю.")
             return 0
         cn = pyodbc.connect(dsn, autocommit=True)
         cur = cn.cursor()
@@ -210,7 +214,7 @@ def main():
             inserted += len(chunk)
         cur.close()
         cn.close()
-        print(f"Записано строк: {inserted}")
+        logger.info("Записано строк: %s", inserted)
         return inserted
 
 

--- a/src/finmodel/scripts/wb_spp_fetch_simple.py
+++ b/src/finmodel/scripts/wb_spp_fetch_simple.py
@@ -14,6 +14,8 @@ def main():
 
     import requests
 
+    from finmodel.logger import get_logger
+
     API = "https://card.wb.ru/cards/v4/detail"
     DEST = -1257786  # универсальный регион РФ
     SPP = 30  # персональное СПП (если не нужен — поставьте 0)
@@ -32,6 +34,7 @@ def main():
             yield lst[i : i + n]
 
     def main():
+        logger = get_logger(__name__)
         ap = argparse.ArgumentParser()
         ap.add_argument(
             "nmids",
@@ -73,10 +76,10 @@ def main():
                 w = csv.DictWriter(f, fieldnames=keys)
                 w.writeheader()
                 w.writerows(rows)
-            print(f"Сохранено {len(rows)} строк → {args.out}")
+            logger.info("Сохранено %s строк → %s", len(rows), args.out)
         else:
             for r in rows:  # печать в консоль
-                print(r)
+                logger.info("%s", r)
 
     if __name__ == "__main__":
         main()

--- a/src/finmodel/scripts/wb_tariffs_box_import.py
+++ b/src/finmodel/scripts/wb_tariffs_box_import.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from finmodel.logger import get_logger
 from finmodel.utils.settings import find_setting, load_config, parse_date
+
+logger = get_logger(__name__)
 
 
 def main(config=None):
@@ -14,7 +17,7 @@ def main(config=None):
     base_dir = Path(__file__).resolve().parents[3]
     db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
 
-    print(f"DB:  {db_path}")
+    logger.info("DB: %s", db_path)
 
     # --- Дата запроса: берём из конфигурации (ПериодКонец), иначе сегодня ---
     date_raw = find_setting("ПериодКонец")
@@ -22,14 +25,14 @@ def main(config=None):
         date_param = parse_date(date_raw).strftime("%Y-%m-%d")
     else:
         date_param = datetime.now().strftime("%Y-%m-%d")
-    print(f"Дата для запроса тарифов: {date_param}")
+    logger.info("Дата для запроса тарифов: %s", date_param)
 
     # --- Чтение токенов (перебор до первого рабочего) ---
     df_orgs = pd.DataFrame(config.get("organizations", []))
     tokens = df_orgs.get("Token_WB", pd.Series()).dropna().astype(str).map(str.strip).tolist()
 
     if not tokens:
-        print("❗ Не найдено ни одного токена в 'НастройкиОрганизаций'.")
+        logger.error("Не найдено ни одного токена в 'НастройкиОрганизаций'.")
         raise SystemExit(1)
 
     # --- Итоговая таблица (пересоздаём) ---
@@ -87,25 +90,25 @@ def main(config=None):
         headers = {"Authorization": token}
         try:
             r = requests.get(URL, headers=headers, params=params, timeout=60)
-            print(f"  Тест токена → HTTP {r.status_code}")
+            logger.info("  Тест токена → HTTP %s", r.status_code)
             if r.status_code != 200:
-                print(f"  Ответ: {r.text[:300]}")
+                logger.warning("  Ответ: %s", r.text[:300])
                 return None
             return r.json()
         except Exception as e:
-            print(f"  Ошибка сети: {e}")
+            logger.warning("  Ошибка сети: %s", e)
             return None
 
     data = None
     for i, tk in enumerate(tokens, 1):
-        print(f"\nПробую токен №{i} ...")
+        logger.info("\nПробую токен №%s ...", i)
         data = try_fetch(tk)
         if data:
-            print("  ✅ Данные получены.")
+            logger.info("  ✅ Данные получены.")
             break
 
     if not data:
-        print("\n❗ Не удалось получить тарифы ни с одним токеном. Проверьте сеть/доступ/токены.")
+        logger.error("Не удалось получить тарифы ни с одним токеном. Проверьте сеть/доступ/токены.")
         conn.close()
         raise SystemExit(2)
 
@@ -142,15 +145,15 @@ def main(config=None):
         )
 
     if not rows:
-        print("⚠️ Список складов пуст. Возможно, на эту дату тарификация не определена.")
+        logger.warning("Список складов пуст. Возможно, на эту дату тарификация не определена.")
     else:
         placeholders = ",".join(["?"] * len(FIELDS))
         cur.executemany(f"INSERT INTO {TABLE} VALUES ({placeholders})", rows)
         conn.commit()
-        print(f"✅ Вставлено строк: {len(rows)} в {TABLE}")
+        logger.info("✅ Вставлено строк: %s в %s", len(rows), TABLE)
 
     conn.close()
-    print("\nГотово.")
+    logger.info("Готово.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `finmodel.logger` with default file/console logging
- switch scripts from `print` statements to the shared logger
- document log file location in README

## Testing
- `isort .`
- `black . -l 100`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee46c7d18832a9ee6accf739bea01