### PR TITLE
Add Docker setup and scheduling instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV FINMODEL_SCRIPT=finmodel.scripts.saleswb_import_flat
+
+CMD ["sh", "-c", "python -m ${FINMODEL_SCRIPT}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+services:
+  app:
+    build: .
+    volumes:
+      - ./config.yml:/app/config.yml:ro
+    environment:
+      - FINMODEL_SCRIPT=finmodel.scripts.saleswb_import_flat
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: finmodel
+      POSTGRES_PASSWORD: finmodel
+      POSTGRES_DB: finmodel
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Add Dockerfile for running import scripts via FINMODEL_SCRIPT
- Provide docker-compose example with PostgreSQL service
- Document container usage and scheduling with cron/Task Scheduler

## Testing
- `isort .`
- `black .`
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ee7f171b8832ab2733faa2fa57457