### PR TITLE
Add CLI to generate SQLite database from schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Python-утилиты для импорта и анализа финансовы
    ```bash
    sqlite3 finmodel.db < schema.sql
    # либо через Python без клиента sqlite3
-   python scripts/create_db.py
+   python create_db.py finmodel.db schema.sql
    ```
 4. Скопируйте `config.example.yml` в `config.yml` и заполните путь к базе данных, диапазоны дат и токены. Переменные окружения с такими же ключами переопределяют значения файла.
 5. Запускайте нужный скрипт через модуль пакета или установленную консольную команду, например:

--- a/create_db.py
+++ b/create_db.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""CLI utility to create SQLite database from SQL schema."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from pathlib import Path
+
+
+def create_db(db_path: Path, schema_path: Path) -> None:
+    """Create an SQLite database and populate it using the provided schema."""
+    schema_sql = schema_path.read_text(encoding="utf-8")
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(schema_sql)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create SQLite database from an SQL schema file.")
+    parser.add_argument("db", type=Path, help="Path to the SQLite database to create.")
+    parser.add_argument("schema", type=Path, help="Path to the SQL schema file.")
+    args = parser.parse_args()
+
+    create_db(args.db, args.schema)
+    print(f"Database created at {args.db}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add command-line script to create an SQLite database from a schema file
- document the new script in the README

## Testing
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a00f1e6970832ab55cc3370048844b