### PR TITLE
Clarify CLI usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,21 @@ Python-утилиты для импорта и анализа финансовы
 
 ## CLI usage
 
-The project provides a unified `finmodel` command for running any supported script.
+The project exposes a single `finmodel` command that provides access to every supported script.
 
-List available subcommands:
+Show the available subcommands:
 
 ```bash
 finmodel --help
 ```
 
-Run a subcommand:
+Run one of them:
 
 ```bash
 finmodel run saleswb_import_flat
 ```
 
-The legacy style `python -m finmodel.scripts.*` still functions but is no longer required when using the CLI.
+The previous `python -m finmodel.scripts.*` form still works for compatibility, but the dedicated CLI removes the need for it.
 
 ## Docker
 Docker-образ позволяет запускать любой скрипт импорта в изолированном окружении.


### PR DESCRIPTION
## Summary
- document the `finmodel` command with examples for listing and running subcommands
- note that legacy `python -m finmodel.scripts.*` usage is still supported

## Testing
- `isort .`
- `black .`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a024c04190832a9487c0e7a0a703fa