### PR TITLE
Load organization tokens from Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Python-утилиты для импорта и анализа финансовы
 python -m finmodel.scripts.dump_schema --db finmodel.db --output schema.sql
 ```
 
-4. Скопируйте `config.example.yml` в `config.yml` и заполните путь к базе данных,
-   диапазоны дат и токены. Переменные окружения с такими же ключами переопределяют
-   значения файла.
+4. Скопируйте `config.example.yml` в `config.yml` и заполните диапазоны дат.
+   Файл `Настройки.xlsm` с колонками `id`, `Организация` и `Token_WB` должен
+   находиться в корне проекта рядом с базой данных `finmodel.db`. Переменные
+   окружения с такими же ключами переопределяют значения файла конфигурации.
 5. Запускайте нужный скрипт через модуль пакета, отдельную консольную команду или общий CLI:
    ```bash
    python -m finmodel.scripts.saleswb_import_flat
@@ -118,14 +119,21 @@ docker build -t finmodel .
 Запустите импорт, смонтировав файл конфигурации в контейнер:
 
 ```bash
-docker run --rm -v $(pwd)/config.yml:/app/config.yml finmodel
+docker run --rm \
+  -v $(pwd)/config.yml:/app/config.yml \
+  -v $(pwd)/Настройки.xlsm:/app/Настройки.xlsm \
+  -v $(pwd)/finmodel.db:/app/finmodel.db \
+  finmodel
 ```
 
 Замените скрипт с помощью переменной `FINMODEL_SCRIPT`:
 
 ```bash
 docker run --rm -e FINMODEL_SCRIPT=finmodel.scripts.orderswb_import_flat \
-  -v $(pwd)/config.yml:/app/config.yml finmodel
+  -v $(pwd)/config.yml:/app/config.yml \
+  -v $(pwd)/Настройки.xlsm:/app/Настройки.xlsm \
+  -v $(pwd)/finmodel.db:/app/finmodel.db \
+  finmodel
 ```
 
 Чтобы использовать PostgreSQL вместо SQLite, поднимите приложение через `docker-compose`:
@@ -137,6 +145,8 @@ services:
     build: .
     volumes:
       - ./config.yml:/app/config.yml:ro
+      - ./Настройки.xlsm:/app/Настройки.xlsm:ro
+      - ./finmodel.db:/app/finmodel.db
     environment:
       - FINMODEL_SCRIPT=finmodel.scripts.saleswb_import_flat
     depends_on:
@@ -166,7 +176,11 @@ docker-compose up --build
 Выполните `crontab -e` и добавьте строку:
 
 ```
-0 3 * * * docker run --rm -v /path/to/config.yml:/app/config.yml finmodel
+0 3 * * * docker run --rm \
+  -v /path/to/config.yml:/app/config.yml \
+  -v /path/to/Настройки.xlsm:/app/Настройки.xlsm \
+  -v /path/to/finmodel.db:/app/finmodel.db \
+  finmodel
 ```
 
 Этот пример запускает импорт каждый день в 03:00.
@@ -175,7 +189,10 @@ docker-compose up --build
 Создайте простую задачу, которая выполняет:
 
 ```
-docker run --rm -v C:\path\to\config.yml:/app/config.yml finmodel
+docker run --rm -v C:\path\to\config.yml:/app/config.yml \
+  -v C:\path\to\Настройки.xlsm:/app/Настройки.xlsm \
+  -v C:\path\to\finmodel.db:/app/finmodel.db \
+  finmodel
 ```
 
 Настройте триггер с нужным интервалом.

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,11 +1,3 @@
-db_path: /path/to/finmodel.db
 settings:
   ПериодНачало: '2023-01-01'
   ПериодКонец: '2023-01-31'
-organizations:
-  - id: 1
-    Организация: 'Org1'
-    Token_WB: 'token1'
-  - id: 2
-    Организация: 'Org2'
-    Token_WB: 'token2'

--- a/src/finmodel/scripts/adv_campaigns_details_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_details_import_flat.py
@@ -7,24 +7,22 @@ import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import load_config
+from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
-    # --- Пути ---
+def main() -> None:
+    # --- Paths ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
     logger.info("DB: %s", db_path)
 
-    # --- Читаем организации/токены ---
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    # --- Load organizations/tokens ---
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Итоговая плоская таблица (пересоздаём на каждый запуск) ---

--- a/src/finmodel/scripts/adv_campaigns_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_import_flat.py
@@ -7,24 +7,22 @@ import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import load_config
+from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
-    # --- Пути ---
+def main() -> None:
+    # --- Paths ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
     logger.info("DB: %s", db_path)
 
-    # --- Читаем организации/токены ---
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    # --- Load organizations/tokens ---
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         return
 
     # --- Итоговые поля таблицы ---

--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -1,4 +1,4 @@
-def main(config=None):
+def main() -> None:
     # -*- coding: utf-8 -*-
     import random
     import sqlite3
@@ -10,15 +10,13 @@ def main(config=None):
     import requests
 
     from finmodel.logger import get_logger
-    from finmodel.utils.settings import load_config
+    from finmodel.utils.settings import load_organizations
 
     logger = get_logger(__name__)
 
-    config = config or load_config()
-
     # ---------- Paths ----------
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
     logger.info("DB: %s", db_path)
 
     # ---------- Period (last 7 days via interval) ----------
@@ -78,10 +76,9 @@ def main(config=None):
         _last_post_ts = now
 
     # ---------- Orgs/tokens ----------
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # ---------- DB & target table ----------

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -2,26 +2,23 @@ import sqlite3
 import time
 from pathlib import Path
 
-import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import load_config
+from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
-    # 📌 Пути к базе
+def main() -> None:
+    # 📌 Paths
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
-    # 📌 Чтение таблицы организаций
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    # 📌 Load organizations
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         return
 
     # 📌 Подключение к базе

--- a/src/finmodel/scripts/nm_report_history_import.py
+++ b/src/finmodel/scripts/nm_report_history_import.py
@@ -3,20 +3,18 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import load_config
+from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
-    # --- Пути ---
+def main() -> None:
+    # --- Paths ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
     logger.info("DB: %s", db_path)
 
@@ -26,11 +24,10 @@ def main(config=None):
     date_to = today.strftime("%Y-%m-%d")
     logger.info("Период запроса: %s .. %s", date_from, date_to)
 
-    # --- Чтение организаций и токенов ---
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    # --- Load organizations and tokens ---
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Подключение к БД ---

--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -3,36 +3,33 @@ import sqlite3
 import time
 from pathlib import Path
 
-import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_config, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, parse_date
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
+def main() -> None:
     # Максимальный размер страницы, заявленный в документации WB API
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60
 
-    # --- Пути ---
+    # --- Paths ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
     # --- Получаем период загрузки ---
     period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
     period_end = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
     logger.info("Период загрузки заказов: %s .. %s", period_start, period_end)
 
-    # --- Чтение организаций ---
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    # --- Load organizations ---
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Все возможные поля заказа (WB-API) ---

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -3,20 +3,18 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_config, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, parse_date
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
+def main() -> None:
     # ---------------- Paths ----------------
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
     logger.info("DB: %s", db_path)
 
@@ -53,11 +51,10 @@ def main(config=None):
 
     logger.info("Период: %s .. %s", period_start, period_end)
 
-    # Orgs with tokens
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    # Organizations with tokens
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # ---------------- DB: table ----------------

--- a/src/finmodel/scripts/paid_storage_import_incremental.py
+++ b/src/finmodel/scripts/paid_storage_import_incremental.py
@@ -3,20 +3,18 @@ import time
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
-import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import load_config
+from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
+def main() -> None:
     # ---------- Paths ----------
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
     logger.info("DB: %s", db_path)
 
@@ -37,10 +35,9 @@ def main(config=None):
         time.sleep(sec)
 
     # ---------- Orgs ----------
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropna()
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # ---------- DB ----------

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -3,35 +3,32 @@ import sqlite3
 import time
 from pathlib import Path
 
-import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_config, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, parse_date
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
+def main() -> None:
     # Максимальный размер страницы, заявленный в документации WB API
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60
 
-    # --- Пути ---
+    # --- Paths ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
     # --- Получаем "ПериодНачало" ---
     period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
     logger.info("Дата начала загрузки остатков: %s", period_start)
 
-    # --- Чтение организаций ---
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    df_orgs = df_orgs[["id", "Организация", "Token_WB"]].dropна()
+    # --- Load organizations ---
+    df_orgs = load_organizations()
     if df_orgs.empty:
-        logger.error("Конфигурация не содержит организаций с токенами.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)
 
     # --- Все возможные поля остатков (WB-API) ---

--- a/src/finmodel/scripts/wbtariffs_commission_import.py
+++ b/src/finmodel/scripts/wbtariffs_commission_import.py
@@ -1,26 +1,24 @@
 import sqlite3
 from pathlib import Path
 
-import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import load_config
+from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
 
 
-def main(config=None):
-    config = config or load_config()
-    # --- Пути ---
+def main() -> None:
+    # --- Paths ---
     base_dir = Path(__file__).resolve().parents[3]
-    db_path = Path(config.get("db_path", base_dir / "finmodel.db"))
+    db_path = base_dir / "finmodel.db"
 
-    # --- Чтение всех токенов ---
-    df_orgs = pd.DataFrame(config.get("organizations", []))
-    tokens = df_orgs.get("Token_WB", pd.Series()).dropna().astype(str).tolist()
+    # --- Load all tokens ---
+    df_orgs = load_organizations()
+    tokens = df_orgs["Token_WB"].dropna().astype(str).tolist()
     if not tokens:
-        logger.error("Конфигурация не содержит токенов.")
+        logger.error("Настройки.xlsm не содержит организаций с токенами.")
         return
 
     # --- Поля по документации WB ---

--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -57,3 +57,21 @@ def parse_date(dt) -> datetime:
         except ValueError:
             continue
     return pd.to_datetime(s).to_pydatetime()
+
+
+def load_organizations(path: str | Path | None = None, sheet: str = "Настройки") -> pd.DataFrame:
+    """Load organizations and tokens from an Excel workbook.
+
+    The workbook ``Настройки.xlsm`` is expected to live in the project root.
+    If ``path`` is provided, it overrides the default location. The returned
+    dataframe contains three columns: ``id``, ``Организация`` and ``Token_WB``.
+    Missing or empty rows are dropped.
+    """
+
+    base_dir = Path(__file__).resolve().parents[3]
+    xls_path = Path(path or base_dir / "Настройки.xlsm")
+    if not xls_path.exists():
+        return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
+    df = pd.read_excel(xls_path, sheet_name=sheet)
+    cols = ["id", "Организация", "Token_WB"]
+    return df[cols].dropna()


### PR DESCRIPTION
## Summary
- read Wildberries organization tokens from `Настройки.xlsm`
- remove organization configuration from scripts and example config
- document Excel- and DB-file requirements for Docker and scheduling

## Testing
- `isort src/finmodel/utils/settings.py src/finmodel/scripts/adv_campaigns_details_import_flat.py src/finmodel/scripts/adv_campaigns_import_flat.py src/finmodel/scripts/adv_fullstats_import_flat.py src/finmodel/scripts/katalog.py src/finmodel/scripts/nm_report_history_import.py src/finmodel/scripts/paid_storage_import_flat.py src/finmodel/scripts/paid_storage_import_incremental.py src/finmodel/scripts/wb_tariffs_box_import.py src/finmodel/scripts/wbtariffs_commission_import.py src/finmodel/scripts/orderswb_import_flat.py src/finmodel/scripts/saleswb_import_flat.py src/finmodel/scripts/stockswb_import_flat.py`
- `black -l 100 src/finmodel/utils/settings.py src/finmodel/scripts/adv_campaigns_details_import_flat.py src/finmodel/scripts/adv_campaigns_import_flat.py src/finmodel/scripts/adv_fullstats_import_flat.py src/finmodel/scripts/katalog.py src/finmodel/scripts/nm_report_history_import.py src/finmodel/scripts/paid_storage_import_flat.py src/finmodel/scripts/paid_storage_import_incremental.py src/finmodel/scripts/wb_tariffs_box_import.py src/finmodel/scripts/wbtariffs_commission_import.py src/finmodel/scripts/orderswb_import_flat.py src/finmodel/scripts/saleswb_import_flat.py src/finmodel/scripts/stockswb_import_flat.py`
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a039558728832a863248557a8aaf8c