### PR TITLE
Handle Typer command structures in menu

### DIFF
--- a/src/finmodel/cli.py
+++ b/src/finmodel/cli.py
@@ -34,7 +34,12 @@ if scripts_dir.exists():
 @app.command()
 def menu() -> None:
     """Interactive menu to run common commands."""
-    command_names = sorted(name for name in app.registered_commands if name != "menu")
+    registered = app.registered_commands
+    if isinstance(registered, dict):
+        command_map = {name: cmd for name, cmd in registered.items() if name and name != "menu"}
+    else:
+        command_map = {cmd.name: cmd for cmd in registered if cmd.name and cmd.name != "menu"}
+    command_names = sorted(command_map.keys())
     if not command_names:
         typer.echo("No commands available.")
         return
@@ -54,7 +59,7 @@ def menu() -> None:
             typer.echo("Invalid choice. Please try again.")
             continue
         try:
-            app.registered_commands[command_name].callback()
+            command_map[command_name].callback()
         except Exception as exc:  # pragma: no cover - defensive
             typer.echo(f"Error: {exc}")
         if not typer.confirm("Return to main menu?", default=True):


### PR DESCRIPTION
## Summary
- Normalize Typer's registered commands to support both list and dict forms in the interactive menu
- Sort command names and invoke callbacks from the built map

## Testing
- `python -m compileall -q .`
- `pytest`
- `finmodel menu`


------
https://chatgpt.com/codex/tasks/task_e_68a075f057ac832aaa9502c67e22de66