### PR TITLE
Validate required columns in katalog import

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ finmodel menu
 
 ```text
 =========== Finmodel 2.0 ===========
- 1. orderswb_import_flat
- 2. saleswb_import_flat
- 3. katalog
- 0. Exit
+1. orderswb_import_flat
+2. saleswb_import_flat
+3. katalog
+0. Exit
 ====================================
 Select an option:
 ```
@@ -105,6 +105,10 @@ Select an option:
 Список формируется автоматически из зарегистрированных команд. Введите номер пункта
 и нажмите `Enter`. Параметры команд можно вводить интерактивно, когда скрипт их
 запрашивает. Для выхода из меню выберите `0`.
+
+> **Note**
+> `katalog` and other data-import scripts expect the workbook `Настройки.xlsm` to
+> contain the columns `id`, `Организация` and `Token_WB`.
 
 ## Docker
 Docker-образ позволяет запускать любой скрипт импорта в изолированном окружении.

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -7,6 +7,9 @@ import requests
 from finmodel.logger import get_logger
 from finmodel.utils.settings import load_organizations
 
+# Keep REQUIRED_COLUMNS in sync with ``load_organizations`` implementation.
+REQUIRED_COLUMNS = {"id", "Организация", "Token_WB"}
+
 logger = get_logger(__name__)
 
 
@@ -17,6 +20,15 @@ def main() -> None:
 
     # 📌 Load organizations
     df_orgs = load_organizations()
+
+    missing_cols = REQUIRED_COLUMNS - set(df_orgs.columns)
+    if missing_cols:
+        logger.error(
+            "Настройки.xlsm is missing required columns: %s",
+            ", ".join(sorted(missing_cols)),
+        )
+        return
+
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         return


### PR DESCRIPTION
## Summary
- ensure katalog validates presence of id, Организация, and Token_WB columns before processing
- document required columns for import scripts

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07dc91f54832aabeb12f354403b50