### PR TITLE
Handle missing organization columns gracefully

### DIFF
--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -8,7 +8,10 @@ from typing import Any, Dict
 import pandas as pd
 import yaml
 
+from finmodel.logger import get_logger
+
 _config: Dict[str, Any] | None = None
+logger = get_logger(__name__)
 
 
 def load_config(path: str | Path | None = None) -> Dict[str, Any]:
@@ -74,4 +77,10 @@ def load_organizations(path: str | Path | None = None, sheet: str = "Настр�
         return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
     df = pd.read_excel(xls_path, sheet_name=sheet)
     cols = ["id", "Организация", "Token_WB"]
+    missing_cols = [c for c in cols if c not in df.columns]
+    if missing_cols:
+        logger.warning(
+            "Missing columns %s in organizations workbook %s", ", ".join(missing_cols), xls_path
+        )
+        return pd.DataFrame(columns=cols)
     return df[cols].dropna()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,10 +2,11 @@ import datetime
 import sys
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-from finmodel.utils.settings import parse_date
+from finmodel.utils.settings import load_organizations, parse_date
 
 
 @pytest.mark.parametrize(
@@ -18,3 +19,13 @@ from finmodel.utils.settings import parse_date
 )
 def test_parse_date(raw, expected):
     assert parse_date(raw) == expected
+
+
+def test_load_organizations_missing_columns(tmp_path):
+    df = pd.DataFrame({"id": [1], "Организация": ["Org"]})
+    xls = tmp_path / "orgs.xlsx"
+    with pd.ExcelWriter(xls) as writer:
+        df.to_excel(writer, sheet_name="Настройки", index=False)
+    result = load_organizations(xls)
+    assert list(result.columns) == ["id", "Организация", "Token_WB"]
+    assert result.empty


### PR DESCRIPTION
## Summary
- avoid KeyError in `load_organizations` by checking for expected columns
- log warning and return empty DataFrame when columns are missing
- test missing-column scenario for `load_organizations`

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07a643784832abcfea774455e7432