### PR TITLE
Normalize organization header checks

### DIFF
--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -76,11 +76,15 @@ def load_organizations(path: str | Path | None = None, sheet: str = "Настр�
     if not xls_path.exists():
         return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
     df = pd.read_excel(xls_path, sheet_name=sheet)
-    cols = ["id", "Организация", "Token_WB"]
-    missing_cols = [c for c in cols if c not in df.columns]
+    df.columns = df.columns.str.strip()
+    required = {"id": "id", "организация": "Организация", "token_wb": "Token_WB"}
+    normalized = {c.lower(): c for c in df.columns}
+    missing_cols = [required[k] for k in required if k not in normalized]
     if missing_cols:
         logger.warning(
             "Missing columns %s in organizations workbook %s", ", ".join(missing_cols), xls_path
         )
-        return pd.DataFrame(columns=cols)
-    return df[cols].dropna()
+        return pd.DataFrame(columns=list(required.values()))
+    rename_map = {normalized[k]: v for k, v in required.items()}
+    df = df.rename(columns=rename_map)
+    return df[list(required.values())].dropna()

--- a/tests/test_load_organizations.py
+++ b/tests/test_load_organizations.py
@@ -36,6 +36,16 @@ def mock_read_excel_missing(monkeypatch, tmp_path):
     return xls
 
 
+@pytest.fixture
+def excel_mixed_headers(tmp_path):
+    """Create an Excel file with spaced and case-varied headers."""
+    df = pd.DataFrame({"ID": [1], "Организация ": ["Org"], "token_wb": ["tok"]})
+    xls = tmp_path / "orgs.xlsx"
+    with pd.ExcelWriter(xls) as writer:
+        df.to_excel(writer, sheet_name="Настройки", index=False)
+    return xls
+
+
 def test_load_organizations_with_missing_column(excel_missing_token):
     df = load_organizations(excel_missing_token)
     assert list(df.columns) == ["id", "Организация", "Token_WB"]
@@ -46,6 +56,12 @@ def test_load_organizations_with_mocked_read_excel(mock_read_excel_missing):
     df = load_organizations(mock_read_excel_missing)
     assert list(df.columns) == ["id", "Организация", "Token_WB"]
     assert df.empty
+
+
+def test_load_organizations_normalizes_headers(excel_mixed_headers):
+    df = load_organizations(excel_mixed_headers)
+    assert list(df.columns) == ["id", "Организация", "Token_WB"]
+    assert df.loc[0, "Token_WB"] == "tok"
 
 
 def test_katalog_handles_missing_columns(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- Normalize Excel headers and check required columns case-insensitively
- Add test to ensure loader handles spaces and mixed case in headers

## Testing
- `python -m isort src/finmodel/utils/settings.py tests/test_load_organizations.py`
- `python -m black src/finmodel/utils/settings.py tests/test_load_organizations.py`
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a08408fad4832aab858b93ffa41d72