### PR TITLE
Log actual columns when organizations workbook missing headers

### DIFF
--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -82,7 +82,10 @@ def load_organizations(path: str | Path | None = None, sheet: str = "Настр�
     missing_cols = [required[k] for k in required if k not in normalized]
     if missing_cols:
         logger.warning(
-            "Missing columns %s in organizations workbook %s", ", ".join(missing_cols), xls_path
+            "Expected columns %s but found %s in organizations workbook %s",
+            list(required.values()),
+            list(df.columns),
+            xls_path,
         )
         return pd.DataFrame(columns=list(required.values()))
     rename_map = {normalized[k]: v for k, v in required.items()}

--- a/tests/test_load_organizations.py
+++ b/tests/test_load_organizations.py
@@ -64,6 +64,13 @@ def test_load_organizations_normalizes_headers(excel_mixed_headers):
     assert df.loc[0, "Token_WB"] == "tok"
 
 
+def test_load_organizations_logs_expected_and_actual_columns(excel_missing_token, caplog):
+    with caplog.at_level("WARNING", logger="finmodel.utils.settings"):
+        load_organizations(excel_missing_token)
+    assert "['id', 'Организация', 'Token_WB']" in caplog.text
+    assert "['id', 'Организация']" in caplog.text
+
+
 def test_katalog_handles_missing_columns(monkeypatch, caplog):
     df = pd.DataFrame({"id": [1], "Организация": ["Org"]})
     monkeypatch.setattr(katalog, "load_organizations", lambda: df)


### PR DESCRIPTION
## Summary
- Log expected and actual column lists when required headers are missing in `load_organizations`
- Add test verifying log message includes expected and found columns

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a085e76a18832a927f510aba114418