### PR TITLE
Log katalog header issues distinctly

### DIFF
--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -20,17 +20,21 @@ def main() -> None:
 
     # 📌 Load organizations
     df_orgs = load_organizations()
+    headers = list(df_orgs.columns)
 
-    missing_cols = REQUIRED_COLUMNS - set(df_orgs.columns)
+    missing_cols = REQUIRED_COLUMNS - set(headers)
     if missing_cols:
         logger.error(
-            "Настройки.xlsm is missing required columns: %s",
+            "Настройки.xlsm is missing required columns: %s. Headers found: %s",
             ", ".join(sorted(missing_cols)),
+            headers,
         )
         return
 
     if df_orgs.empty:
-        logger.error("Настройки.xlsm не содержит организаций с токенами.")
+        logger.error(
+            "Настройки.xlsm не содержит организаций с токенами. Headers found: %s", headers
+        )
         return
 
     # 📌 Подключение к базе

--- a/tests/test_load_organizations.py
+++ b/tests/test_load_organizations.py
@@ -79,6 +79,7 @@ def test_katalog_handles_missing_columns(monkeypatch, caplog):
     with caplog.at_level("ERROR"):
         katalog.main()
     assert "missing required columns" in caplog.text
+    assert "['id', 'Организация']" in caplog.text
     connect.assert_not_called()
 
 
@@ -90,4 +91,5 @@ def test_katalog_handles_empty_dataframe(monkeypatch, caplog):
     with caplog.at_level("ERROR"):
         katalog.main()
     assert "не содержит организаций" in caplog.text
+    assert "['id', 'Организация', 'Token_WB']" in caplog.text
     connect.assert_not_called()


### PR DESCRIPTION
## Summary
- Differentiate between missing required columns and no organizations in `katalog`
- Log normalized header list for clarity
- Expand tests to validate header logging

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a087661074832a9b5095f70c05578c