### PR TITLE
Handle blank leading rows in organization Excel

### DIFF
--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -77,7 +77,16 @@ def load_organizations(path: str | Path | None = None, sheet: str | None = None)
     xls_path = Path(path or base_dir / "Настройки.xlsm")
     if not xls_path.exists():
         return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
-    df = pd.read_excel(xls_path, sheet_name=sheet)
+    df = pd.read_excel(xls_path, sheet_name=sheet, header=None)
+    df = df.dropna(how="all")
+    if df.empty:
+        return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
+    header_idx = df.index[0]
+    header = df.loc[header_idx].astype(str).str.strip()
+    header.name = None
+    df = df.loc[df.index > header_idx]
+    df.columns = header
+    df = df.dropna(how="all").reset_index(drop=True)
     df.columns = df.columns.str.strip()
     required = {"id": "id", "организация": "Организация", "token_wb": "Token_WB"}
     normalized = {c.lower(): c for c in df.columns}


### PR DESCRIPTION
## Summary
- ignore leading empty rows when reading organizations workbook
- test organization loader with blank leading rows and patched Excel reader

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09514388c832aac10960c4148d0d7