### PR TITLE
Load period from Excel settings

### DIFF
--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -7,7 +7,12 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_organizations, parse_date
+from finmodel.utils.settings import (
+    find_setting,
+    load_organizations,
+    load_period,
+    parse_date,
+)
 
 logger = get_logger(__name__)
 
@@ -22,8 +27,12 @@ def main() -> None:
     db_path = base_dir / "finmodel.db"
 
     # --- Получаем период загрузки ---
-    period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
-    period_end = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
+    period_start_raw, period_end_raw = load_period()
+    if not period_start_raw or not period_end_raw:
+        logger.error("Settings do not include ПериодНачало/ПериодКонец.")
+        raise SystemExit(1)
+    period_start = parse_date(period_start_raw).strftime("%Y-%m-%dT%H:%M:%S")
+    period_end = parse_date(period_end_raw).strftime("%Y-%m-%dT%H:%M:%S")
     logger.info("Период загрузки заказов: %s .. %s", period_start, period_end)
 
     # --- Load organizations ---

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_organizations, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -36,8 +36,7 @@ def main() -> None:
         time.sleep(sec)
 
     # ---------------- Load settings ----------------
-    period_start_raw = find_setting("ПериодНачало")
-    period_end_raw = find_setting("ПериодКонец")
+    period_start_raw, period_end_raw = load_period()
 
     if not period_start_raw or not period_end_raw:
         logger.error("Settings do not include ПериодНачало/ПериодКонец.")

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -7,7 +7,12 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_organizations, parse_date
+from finmodel.utils.settings import (
+    find_setting,
+    load_organizations,
+    load_period,
+    parse_date,
+)
 
 logger = get_logger(__name__)
 
@@ -22,8 +27,12 @@ def main() -> None:
     db_path = base_dir / "finmodel.db"
 
     # --- Получаем период загрузки ---
-    period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
-    period_end = parse_date(find_setting("ПериодКонец")).strftime("%Y-%m-%dT%H:%M:%S")
+    period_start_raw, period_end_raw = load_period()
+    if not period_start_raw or not period_end_raw:
+        logger.error("Settings do not include ПериодНачало/ПериодКонец.")
+        raise SystemExit(1)
+    period_start = parse_date(period_start_raw).strftime("%Y-%m-%dT%H:%M:%S")
+    period_end = parse_date(period_end_raw).strftime("%Y-%m-%dT%H:%M:%S")
     logger.info("Период загрузки продаж: %s .. %s", period_start, period_end)
 
     # --- Load organizations ---

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -7,7 +7,7 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_organizations, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -22,7 +22,11 @@ def main() -> None:
     db_path = base_dir / "finmodel.db"
 
     # --- Получаем "ПериодНачало" ---
-    period_start = parse_date(find_setting("ПериодНачало")).strftime("%Y-%m-%dT%H:%M:%S")
+    period_start_raw, _ = load_period()
+    if not period_start_raw:
+        logger.error("Settings do not include ПериодНачало.")
+        raise SystemExit(1)
+    period_start = parse_date(period_start_raw).strftime("%Y-%m-%dT%H:%M:%S")
     logger.info("Дата начала загрузки остатков: %s", period_start)
 
     # --- Load organizations ---

--- a/src/finmodel/scripts/wb_tariffs_box_import.py
+++ b/src/finmodel/scripts/wb_tariffs_box_import.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import requests
 
 from finmodel.logger import get_logger
-from finmodel.utils.settings import find_setting, load_organizations, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -18,7 +18,7 @@ def main() -> None:
     logger.info("DB: %s", db_path)
 
     # --- Дата запроса: берём из конфигурации (ПериодКонец), иначе сегодня ---
-    date_raw = find_setting("ПериодКонец")
+    _, date_raw = load_period()
     if date_raw:
         date_param = parse_date(date_raw).strftime("%Y-%m-%d")
     else:


### PR DESCRIPTION
## Summary
- add `load_period` helper to read start/end dates from `Настройки.xlsm`
- switch reporting scripts to use `load_period` instead of environment lookup
- test reading period values with skipped blank rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0987edc24832aa6a0fc9f8cb5d74e