### PR TITLE
Log organizations sheet before loading

### DIFF
--- a/src/finmodel/scripts/adv_campaigns_details_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_details_import_flat.py
@@ -21,6 +21,7 @@ def main() -> None:
 
     # --- Load organizations/tokens ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/adv_campaigns_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_import_flat.py
@@ -21,6 +21,7 @@ def main() -> None:
 
     # --- Load organizations/tokens ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -77,6 +77,7 @@ def main() -> None:
 
     # ---------- Orgs/tokens ----------
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -20,6 +20,7 @@ def main() -> None:
 
     # 📌 Load organizations
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
 
     missing_cols = REQUIRED_COLUMNS - set(df_orgs.columns)

--- a/src/finmodel/scripts/nm_report_history_import.py
+++ b/src/finmodel/scripts/nm_report_history_import.py
@@ -26,6 +26,7 @@ def main() -> None:
 
     # --- Load organizations and tokens ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -37,6 +37,7 @@ def main() -> None:
 
     # --- Load organizations ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -52,6 +52,7 @@ def main() -> None:
 
     # Organizations with tokens
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/paid_storage_import_incremental.py
+++ b/src/finmodel/scripts/paid_storage_import_incremental.py
@@ -36,6 +36,7 @@ def main() -> None:
 
     # ---------- Orgs ----------
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -37,6 +37,7 @@ def main() -> None:
 
     # --- Load organizations ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -31,6 +31,7 @@ def main() -> None:
 
     # --- Load organizations ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/src/finmodel/scripts/wb_tariffs_box_import.py
+++ b/src/finmodel/scripts/wb_tariffs_box_import.py
@@ -27,6 +27,7 @@ def main() -> None:
 
     # --- Load tokens (try each until one works) ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     tokens = df_orgs["Token_WB"].dropna().astype(str).map(str.strip).tolist()
 

--- a/src/finmodel/scripts/wbtariffs_commission_import.py
+++ b/src/finmodel/scripts/wbtariffs_commission_import.py
@@ -16,6 +16,7 @@ def main() -> None:
 
     # --- Load all tokens ---
     sheet = find_setting("ORG_SHEET", default="Настройки")
+    logger.info("Using organizations sheet: %s", sheet)
     df_orgs = load_organizations(sheet=sheet)
     tokens = df_orgs["Token_WB"].dropna().astype(str).tolist()
     if not tokens:

--- a/tests/test_load_organizations.py
+++ b/tests/test_load_organizations.py
@@ -132,8 +132,9 @@ def test_katalog_handles_missing_columns(monkeypatch, caplog):
     monkeypatch.setattr(katalog, "load_organizations", lambda **_: df)
     connect = MagicMock()
     monkeypatch.setattr(katalog.sqlite3, "connect", connect)
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("INFO"):
         katalog.main()
+    assert "Using organizations sheet" in caplog.text
     assert "missing required columns" in caplog.text
     connect.assert_not_called()
 
@@ -143,7 +144,8 @@ def test_katalog_handles_empty_dataframe(monkeypatch, caplog):
     monkeypatch.setattr(katalog, "load_organizations", lambda **_: df)
     connect = MagicMock()
     monkeypatch.setattr(katalog.sqlite3, "connect", connect)
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("INFO"):
         katalog.main()
+    assert "Using organizations sheet" in caplog.text
     assert "не содержит организаций" in caplog.text
     connect.assert_not_called()


### PR DESCRIPTION
## Summary
- log the organizations sheet name before calling `load_organizations` in all scripts using it
- update katalog tests to expect the new informational log

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09e7a2b88832a87a5cfdfe0d7b2a5