### PR TITLE
Clarify finmodel CLI usage and update script paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENV FINMODEL_SCRIPT=finmodel.scripts.saleswb_import_flat
+ENV FINMODEL_SCRIPT=saleswb_import_flat
 
-CMD ["sh", "-c", "python -m ${FINMODEL_SCRIPT}"]
+CMD ["sh", "-c", "python -m finmodel.cli ${FINMODEL_SCRIPT}"]

--- a/README.md
+++ b/README.md
@@ -45,22 +45,22 @@ Python-утилиты для импорта и анализа финансовы
 Чтобы выгрузить схему из существующей базы данных:
 
 ```bash
-python -m finmodel.scripts.dump_schema --db finmodel.db --output schema.sql
+python -m finmodel.cli dump_schema --db finmodel.db --output schema.sql
+# или после установки пакета:
+finmodel dump_schema --db finmodel.db --output schema.sql
 ```
 
 4. Скопируйте `config.example.yml` в `config.yml` и заполните диапазоны дат.
    Файл `Настройки.xlsm` с колонками `id`, `Организация` и `Token_WB` должен
    находиться в корне проекта рядом с базой данных `finmodel.db`. Переменные
    окружения с такими же ключами переопределяют значения файла конфигурации.
-5. Запускайте нужный скрипт через модуль пакета, отдельную консольную команду или общий CLI:
+5. Запускайте нужный скрипт через модуль `finmodel.cli`, отдельную консольную команду или общий CLI:
    ```bash
-   python -m finmodel.scripts.saleswb_import_flat
+   PYTHONPATH=src python -m finmodel.cli saleswb_import_flat
    # либо после установки пакета:
    saleswb_import_flat
    # или через единый интерфейс:
    finmodel saleswb_import_flat
-   # или через модуль пакета:
-   PYTHONPATH=src python -m finmodel saleswb_import_flat
    ```
 
 ## Конфигурация
@@ -98,6 +98,11 @@ export ORG_SHEET=НастройкиОрганизаций
 ## Использование CLI
 
 Проект предоставляет единую команду `finmodel`, которая даёт доступ ко всем поддерживаемым скриптам.
+Без установки пакета можно воспользоваться модулем `finmodel.cli`:
+
+```bash
+python -m finmodel.cli --help
+```
 
 Выведите список доступных подкоманд:
 
@@ -112,7 +117,7 @@ finmodel saleswb_import_flat
 ```
 
 Старый формат `python -m finmodel.scripts.*` по-прежнему работает для совместимости,
-но теперь в нём нет необходимости.
+но предпочтительнее использовать `python -m finmodel.cli <команда>` или консольную команду `finmodel`.
 
 ### Интерактивное меню
 
@@ -164,7 +169,7 @@ docker run --rm \
 Замените скрипт с помощью переменной `FINMODEL_SCRIPT`:
 
 ```bash
-docker run --rm -e FINMODEL_SCRIPT=finmodel.scripts.orderswb_import_flat \
+docker run --rm -e FINMODEL_SCRIPT=orderswb_import_flat \
   -v $(pwd)/config.yml:/app/config.yml \
   -v $(pwd)/Настройки.xlsm:/app/Настройки.xlsm \
   -v $(pwd)/finmodel.db:/app/finmodel.db \
@@ -183,7 +188,7 @@ services:
       - ./Настройки.xlsm:/app/Настройки.xlsm:ro
       - ./finmodel.db:/app/finmodel.db
     environment:
-      - FINMODEL_SCRIPT=finmodel.scripts.saleswb_import_flat
+      - FINMODEL_SCRIPT=saleswb_import_flat
     depends_on:
       - db
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./config.yml:/app/config.yml:ro
     environment:
-      - FINMODEL_SCRIPT=finmodel.scripts.saleswb_import_flat
+      - FINMODEL_SCRIPT=saleswb_import_flat
     depends_on:
       - db
 

--- a/src/finmodel/scripts/wb_spp_fetch.py
+++ b/src/finmodel/scripts/wb_spp_fetch.py
@@ -38,7 +38,7 @@ def main():
     def resolve_db_path(cli_path: str | None) -> Path:
         if cli_path:
             return Path(cli_path).expanduser().resolve()
-        #  …/scriptsPB/wb_spp_fetch.py → …/finmodel.db
+        #  …/src/finmodel/scripts/wb_spp_fetch.py → …/finmodel.db
         return Path(__file__).resolve().parents[3] / "finmodel.db"
 
     args = parse_args()


### PR DESCRIPTION
## Summary
- document how to call utilities through `finmodel.cli`
- update Docker instructions and defaults for unified CLI
- fix leftover reference to obsolete `scriptsPB` path

## Testing
- `isort .`
- `black README.md` *(fails: Cannot parse for target version Python 3.10: 3:15: Python-утилиты для импорта и анализа финансовых данных с маркетплейса Wildberries.)*
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d6d28a94832a925a30d9ebe25b15