### PR TITLE
Use central path helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ finmodel dump_schema --db finmodel.db --output schema.sql
    Файл `Настройки.xlsm` с колонками `id`, `Организация` и `Token_WB` должен
    находиться в корне проекта рядом с базой данных `finmodel.db`. Переменные
    окружения с такими же ключами переопределяют значения файла конфигурации.
+   Путь к корню проекта можно задать через `FINMODEL_PROJECT_ROOT`, а путь к
+   базе данных — через `FINMODEL_DB_PATH`.
 5. Запускайте нужный скрипт через единый CLI:
    ```bash
    finmodel saleswb_import_flat

--- a/src/finmodel/logger.py
+++ b/src/finmodel/logger.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import Optional
 
-LOG_DIR = Path(__file__).resolve().parents[2] / "log"
+from finmodel.utils.paths import get_project_root
+
+LOG_DIR = get_project_root() / "log"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOG_DIR / "finmodel.log"
 

--- a/src/finmodel/scripts/adv_campaigns_details_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_details_import_flat.py
@@ -1,12 +1,12 @@
 import sqlite3
 import time
 from datetime import datetime
-from pathlib import Path
 
 import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
@@ -14,8 +14,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
 

--- a/src/finmodel/scripts/adv_campaigns_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_import_flat.py
@@ -1,12 +1,12 @@
 import sqlite3
 import time
 from datetime import datetime
-from pathlib import Path
 
 import pandas as pd
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
@@ -14,8 +14,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
 

--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -4,19 +4,18 @@ def main() -> None:
     import sqlite3
     import time
     from datetime import datetime, timedelta
-    from pathlib import Path
 
     import pandas as pd
     import requests
 
     from finmodel.logger import get_logger
+    from finmodel.utils.paths import get_db_path
     from finmodel.utils.settings import load_organizations
 
     logger = get_logger(__name__)
 
     # ---------- Paths ----------
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
     logger.info("DB: %s", db_path)
 
     # ---------- Period (last 7 days via interval) ----------

--- a/src/finmodel/scripts/finotchet_import.py
+++ b/src/finmodel/scripts/finotchet_import.py
@@ -1,17 +1,16 @@
 import ast
 import json
 import sqlite3
-from pathlib import Path
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 
 logger = get_logger(__name__)
 
 
 def main():
     # --- Пути к базе ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     # --- Список всех WB-полей ---
     WB_FIELDS = [

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -1,10 +1,10 @@
 import sqlite3
 import time
-from pathlib import Path
 
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations
 
 # Keep REQUIRED_COLUMNS in sync with ``load_organizations`` implementation.
@@ -15,8 +15,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # 📌 Paths
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     # 📌 Load organizations
     sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")

--- a/src/finmodel/scripts/nm_report_history_import.py
+++ b/src/finmodel/scripts/nm_report_history_import.py
@@ -1,11 +1,11 @@
 import sqlite3
 import time
 from datetime import datetime, timedelta
-from pathlib import Path
 
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
@@ -13,8 +13,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
 

--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -1,12 +1,12 @@
 import json
 import sqlite3
 import time
-from pathlib import Path
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
@@ -18,8 +18,7 @@ def main() -> None:
     REQUEST_TIMEOUT = 60
 
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     # --- Получаем период загрузки ---
     period_start_raw, period_end_raw = load_period()

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -1,11 +1,11 @@
 import sqlite3
 import time
 from datetime import datetime, timedelta
-from pathlib import Path
 
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
@@ -13,8 +13,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # ---------------- Paths ----------------
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
 

--- a/src/finmodel/scripts/paid_storage_import_incremental.py
+++ b/src/finmodel/scripts/paid_storage_import_incremental.py
@@ -1,11 +1,11 @@
 import sqlite3
 import time
 from datetime import date, datetime, timedelta
-from pathlib import Path
 
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
@@ -13,8 +13,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # ---------- Paths ----------
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
 

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -1,12 +1,12 @@
 import json
 import sqlite3
 import time
-from pathlib import Path
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
@@ -18,8 +18,7 @@ def main() -> None:
     REQUEST_TIMEOUT = 60
 
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     # --- Получаем период загрузки ---
     period_start_raw, period_end_raw = load_period()

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -1,12 +1,12 @@
 import json
 import sqlite3
 import time
-from pathlib import Path
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
@@ -18,8 +18,7 @@ def main() -> None:
     REQUEST_TIMEOUT = 60
 
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     # --- Получаем "ПериодНачало" ---
     period_start_raw, _ = load_period()

--- a/src/finmodel/scripts/wb_spp_fetch.py
+++ b/src/finmodel/scripts/wb_spp_fetch.py
@@ -19,6 +19,7 @@ def main():
     import requests
 
     from finmodel.logger import get_logger
+    from finmodel.utils.paths import get_db_path
 
     # ──────────────────────────────────────────────────────────────────────────────
     # 1. Параметры и путь к базе
@@ -38,8 +39,7 @@ def main():
     def resolve_db_path(cli_path: str | None) -> Path:
         if cli_path:
             return Path(cli_path).expanduser().resolve()
-        #  …/src/finmodel/scripts/wb_spp_fetch.py → …/finmodel.db
-        return Path(__file__).resolve().parents[3] / "finmodel.db"
+        return get_db_path()
 
     args = parse_args()
     DB_PATH: Path = resolve_db_path(args.db)

--- a/src/finmodel/scripts/wb_tariffs_box_import.py
+++ b/src/finmodel/scripts/wb_tariffs_box_import.py
@@ -1,10 +1,10 @@
 import sqlite3
 from datetime import datetime
-from pathlib import Path
 
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
@@ -12,8 +12,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
 

--- a/src/finmodel/scripts/wbtariffs_commission_import.py
+++ b/src/finmodel/scripts/wbtariffs_commission_import.py
@@ -1,9 +1,9 @@
 import sqlite3
-from pathlib import Path
 
 import requests
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import load_organizations
 
 logger = get_logger(__name__)
@@ -11,8 +11,7 @@ logger = get_logger(__name__)
 
 def main() -> None:
     # --- Paths ---
-    base_dir = Path(__file__).resolve().parents[3]
-    db_path = base_dir / "finmodel.db"
+    db_path = get_db_path()
 
     # --- Load all tokens ---
     df_orgs = load_organizations()

--- a/src/finmodel/utils/paths.py
+++ b/src/finmodel/utils/paths.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_project_root() -> Path:
+    """Return the repository root.
+
+    The location can be overridden by the ``FINMODEL_PROJECT_ROOT`` environment
+    variable. Otherwise the path is resolved relative to this file.
+    """
+    env_root = os.getenv("FINMODEL_PROJECT_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve()
+    return Path(__file__).resolve().parents[3]
+
+
+def get_db_path() -> Path:
+    """Return path to ``finmodel.db``.
+
+    ``FINMODEL_DB_PATH`` environment variable has priority over the default
+    location under the project root.
+    """
+    env_db = os.getenv("FINMODEL_DB_PATH")
+    if env_db:
+        return Path(env_db).expanduser().resolve()
+    return get_project_root() / "finmodel.db"

--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -9,6 +9,7 @@ import pandas as pd
 import yaml
 
 from finmodel.logger import get_logger
+from finmodel.utils.paths import get_project_root
 
 _config: Dict[str, Any] | None = None
 logger = get_logger(__name__)
@@ -26,7 +27,7 @@ def load_config(path: str | Path | None = None) -> Dict[str, Any]:
     """
     global _config
     if _config is None:
-        base_dir = Path(__file__).resolve().parents[3]
+        base_dir = get_project_root()
         cfg_path = Path(path or os.getenv("FINMODEL_CONFIG", base_dir / "config.yml"))
         data: Dict[str, Any] = {}
         if cfg_path.exists():
@@ -73,7 +74,7 @@ def load_organizations(path: str | Path | None = None, sheet: str | None = None)
     """
 
     sheet = sheet or find_setting("ORG_SHEET", default="НастройкиОрганизаций")
-    base_dir = Path(__file__).resolve().parents[3]
+    base_dir = get_project_root()
     xls_path = Path(path or base_dir / "Настройки.xlsm")
     logger.info("Loading organizations from %s sheet %s", xls_path, sheet)
     if not xls_path.exists():
@@ -130,7 +131,7 @@ def load_period(
     """
 
     sheet = sheet or find_setting("ORG_SHEET", default="Настройки")
-    base_dir = Path(__file__).resolve().parents[3]
+    base_dir = get_project_root()
     xls_path = Path(path or base_dir / "Настройки.xlsm")
     if not xls_path.exists():
         return None, None


### PR DESCRIPTION
## Summary
- add `get_project_root` and `get_db_path` helpers with env overrides
- switch scripts and utilities to use path helpers instead of `Path(...parents[3])`
- document `FINMODEL_PROJECT_ROOT` and `FINMODEL_DB_PATH` variables in README

## Testing
- `isort .`
- `black .`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ddf20b80832a8688c429df84abd7