### PR TITLE
Add runtime dependencies to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ description = "Utilities for importing and analyzing Wildberries financial data"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "openpyxl",
+    "pandas",
     "PyYAML>=6.0",
+    "requests",
     "typer>=0.9",
 ]
 


### PR DESCRIPTION
## Summary
- Include openpyxl, pandas, and requests in project dependencies

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0ecc36a58832a9ec65b148338b4f3