### PR TITLE
Move logging configuration into setup function and invoke from CLI

### DIFF
--- a/src/finmodel/__main__.py
+++ b/src/finmodel/__main__.py
@@ -1,6 +1,6 @@
 """Module to allow `python -m finmodel` to run the CLI."""
 
-from .cli import app
+from .cli import main
 
 if __name__ == "__main__":
-    app()
+    main()

--- a/src/finmodel/cli.py
+++ b/src/finmodel/cli.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import typer
 
+from finmodel.logger import setup_logging
+
 app = typer.Typer(help="Finmodel command line interface")
 
 
@@ -69,4 +71,5 @@ def menu() -> None:
 
 def main() -> None:
     """Entry point for console_scripts."""
+    setup_logging()
     app()

--- a/src/finmodel/logger.py
+++ b/src/finmodel/logger.py
@@ -6,19 +6,24 @@ from typing import Optional
 from finmodel.utils.paths import get_project_root
 
 LOG_DIR = get_project_root() / "log"
-LOG_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOG_DIR / "finmodel.log"
 
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
-logging.basicConfig(
-    level=logging.INFO,
-    format=LOG_FORMAT,
-    handlers=[
-        logging.FileHandler(LOG_FILE, encoding="utf-8"),
-        logging.StreamHandler(),
-    ],
-)
+
+def setup_logging() -> None:
+    """Configure logging for the project."""
+    if logging.getLogger().hasHandlers():
+        return
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format=LOG_FORMAT,
+        handlers=[
+            logging.FileHandler(LOG_FILE, encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+    )
 
 
 def get_logger(name: Optional[str] = None) -> logging.Logger:


### PR DESCRIPTION
## Summary
- add `setup_logging` that prepares the log directory and configures logging
- initialize logging in the CLI's `main` function so configuration happens at runtime
- delegate `python -m finmodel` to the CLI entry point so logging is set up consistently

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0f102f450832abe2b7d1727ee9c79