### PR TITLE
Remove unused imports from WB prices script

### DIFF
--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -1,8 +1,6 @@
 def main():
     # file: wb_spp_fetch.py  (v2)
-    import argparse
     import csv
-    import math
 
     # --- NEW: sqlite ---
     import sqlite3


### PR DESCRIPTION
## Summary
- remove unused argparse and math imports from `wb_goods_prices_import_flat`

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1580cc08c832a9c4934c379335031