### PR TITLE
Explicit sheet selection for scripts

### DIFF
--- a/src/finmodel/scripts/adv_campaigns_details_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_details_import_flat.py
@@ -7,7 +7,7 @@ import requests
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations
+from finmodel.utils.settings import find_setting, load_organizations
 
 logger = get_logger(__name__)
 
@@ -18,8 +18,13 @@ def main() -> None:
 
     logger.info("DB: %s", db_path)
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Load organizations/tokens ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/adv_campaigns_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_import_flat.py
@@ -7,7 +7,7 @@ import requests
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations
+from finmodel.utils.settings import find_setting, load_organizations
 
 logger = get_logger(__name__)
 
@@ -18,8 +18,13 @@ def main() -> None:
 
     logger.info("DB: %s", db_path)
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Load organizations/tokens ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         return

--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -10,13 +10,18 @@ def main() -> None:
 
     from finmodel.logger import get_logger
     from finmodel.utils.paths import get_db_path
-    from finmodel.utils.settings import load_organizations
+    from finmodel.utils.settings import find_setting, load_organizations
 
     logger = get_logger(__name__)
 
     # ---------- Paths ----------
     db_path = get_db_path()
     logger.info("DB: %s", db_path)
+
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
 
     # ---------- Period (last 7 days via interval) ----------
     today = datetime.now().date()
@@ -75,7 +80,7 @@ def main() -> None:
         _last_post_ts = now
 
     # ---------- Orgs/tokens ----------
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -19,7 +19,9 @@ def main() -> None:
 
     # 📌 Load organizations
     sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
     logger.info("Using organizations sheet: %s", sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
     df_orgs = load_organizations(sheet=sheet)
 
     missing_cols = REQUIRED_COLUMNS - set(df_orgs.columns)

--- a/src/finmodel/scripts/nm_report_history_import.py
+++ b/src/finmodel/scripts/nm_report_history_import.py
@@ -6,7 +6,7 @@ import requests
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations
+from finmodel.utils.settings import find_setting, load_organizations
 
 logger = get_logger(__name__)
 
@@ -17,6 +17,11 @@ def main() -> None:
 
     logger.info("DB: %s", db_path)
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Период: всегда последние 7 дней (включая сегодня) ---
     today = datetime.now().date()
     date_from = (today - timedelta(days=7)).strftime("%Y-%m-%d")
@@ -24,7 +29,7 @@ def main() -> None:
     logger.info("Период запроса: %s .. %s", date_from, date_to)
 
     # --- Load organizations and tokens ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -7,7 +7,7 @@ from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations, load_period, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -20,8 +20,13 @@ def main() -> None:
     # --- Paths ---
     db_path = get_db_path()
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Получаем период загрузки ---
-    period_start_raw, period_end_raw = load_period()
+    period_start_raw, period_end_raw = load_period(sheet=settings_sheet)
     if not period_start_raw or not period_end_raw:
         logger.error("Settings do not include ПериодНачало/ПериодКонец.")
         raise SystemExit(1)
@@ -30,7 +35,7 @@ def main() -> None:
     logger.info("Период загрузки заказов: %s .. %s", period_start, period_end)
 
     # --- Load organizations ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -6,7 +6,7 @@ import requests
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations, load_period, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -16,6 +16,11 @@ def main() -> None:
     db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
+
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
 
     def daterange_8d(d1: datetime, d2: datetime):
         """Yield (from, to) windows of up to 8 days inclusive."""
@@ -35,7 +40,7 @@ def main() -> None:
         time.sleep(sec)
 
     # ---------------- Load settings ----------------
-    period_start_raw, period_end_raw = load_period()
+    period_start_raw, period_end_raw = load_period(sheet=settings_sheet)
 
     if not period_start_raw or not period_end_raw:
         logger.error("Settings do not include ПериодНачало/ПериодКонец.")
@@ -50,7 +55,7 @@ def main() -> None:
     logger.info("Период: %s .. %s", period_start, period_end)
 
     # Organizations with tokens
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/paid_storage_import_incremental.py
+++ b/src/finmodel/scripts/paid_storage_import_incremental.py
@@ -6,7 +6,7 @@ import requests
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations
+from finmodel.utils.settings import find_setting, load_organizations
 
 logger = get_logger(__name__)
 
@@ -16,6 +16,11 @@ def main() -> None:
     db_path = get_db_path()
 
     logger.info("DB: %s", db_path)
+
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
 
     # ---------- Helpers ----------
     def iso_date(d: date) -> str:
@@ -34,7 +39,7 @@ def main() -> None:
         time.sleep(sec)
 
     # ---------- Orgs ----------
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -7,7 +7,7 @@ from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations, load_period, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -20,8 +20,13 @@ def main() -> None:
     # --- Paths ---
     db_path = get_db_path()
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Получаем период загрузки ---
-    period_start_raw, period_end_raw = load_period()
+    period_start_raw, period_end_raw = load_period(sheet=settings_sheet)
     if not period_start_raw or not period_end_raw:
         logger.error("Settings do not include ПериодНачало/ПериодКонец.")
         raise SystemExit(1)
@@ -30,7 +35,7 @@ def main() -> None:
     logger.info("Период загрузки продаж: %s .. %s", period_start, period_end)
 
     # --- Load organizations ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -7,7 +7,7 @@ from requests.adapters import HTTPAdapter, Retry
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations, load_period, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -20,8 +20,13 @@ def main() -> None:
     # --- Paths ---
     db_path = get_db_path()
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Получаем "ПериодНачало" ---
-    period_start_raw, _ = load_period()
+    period_start_raw, _ = load_period(sheet=settings_sheet)
     if not period_start_raw:
         logger.error("Settings do not include ПериодНачало.")
         raise SystemExit(1)
@@ -29,7 +34,7 @@ def main() -> None:
     logger.info("Дата начала загрузки остатков: %s", period_start)
 
     # --- Load organizations ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     if df_orgs.empty:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")
         raise SystemExit(1)

--- a/src/finmodel/scripts/wb_tariffs_box_import.py
+++ b/src/finmodel/scripts/wb_tariffs_box_import.py
@@ -5,7 +5,7 @@ import requests
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations, load_period, parse_date
+from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
 logger = get_logger(__name__)
 
@@ -16,8 +16,13 @@ def main() -> None:
 
     logger.info("DB: %s", db_path)
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Дата запроса: берём из конфигурации (ПериодКонец), иначе сегодня ---
-    _, date_raw = load_period()
+    _, date_raw = load_period(sheet=settings_sheet)
     if date_raw:
         date_param = parse_date(date_raw).strftime("%Y-%m-%d")
     else:
@@ -25,7 +30,7 @@ def main() -> None:
     logger.info("Дата для запроса тарифов: %s", date_param)
 
     # --- Load tokens (try each until one works) ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     tokens = df_orgs["Token_WB"].dropna().astype(str).map(str.strip).tolist()
 
     if not tokens:

--- a/src/finmodel/scripts/wbtariffs_commission_import.py
+++ b/src/finmodel/scripts/wbtariffs_commission_import.py
@@ -4,7 +4,7 @@ import requests
 
 from finmodel.logger import get_logger
 from finmodel.utils.paths import get_db_path
-from finmodel.utils.settings import load_organizations
+from finmodel.utils.settings import find_setting, load_organizations
 
 logger = get_logger(__name__)
 
@@ -13,8 +13,13 @@ def main() -> None:
     # --- Paths ---
     db_path = get_db_path()
 
+    org_sheet = find_setting("ORG_SHEET", default="НастройкиОрганизаций")
+    settings_sheet = find_setting("SETTINGS_SHEET", default="Настройки")
+    logger.info("Using organizations sheet %s", org_sheet)
+    logger.info("Using settings sheet %s", settings_sheet)
+
     # --- Load all tokens ---
-    df_orgs = load_organizations()
+    df_orgs = load_organizations(sheet=org_sheet)
     tokens = df_orgs["Token_WB"].dropna().astype(str).tolist()
     if not tokens:
         logger.error("Настройки.xlsm не содержит организаций с токенами.")

--- a/tests/scripts/test_orderswb_import_flat.py
+++ b/tests/scripts/test_orderswb_import_flat.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+# Ensure src is importable
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from finmodel.scripts import orderswb_import_flat
+
+
+def test_orderswb_respects_sheet_env(monkeypatch, caplog):
+    monkeypatch.setenv("ORG_SHEET", "OrgSheet")
+    monkeypatch.setenv("SETTINGS_SHEET", "SettingsSheet")
+
+    load_org = MagicMock(return_value=pd.DataFrame())
+    load_period = MagicMock(return_value=("2024-01-01", "2024-01-02"))
+    monkeypatch.setattr(orderswb_import_flat, "load_organizations", load_org)
+    monkeypatch.setattr(orderswb_import_flat, "load_period", load_period)
+    monkeypatch.setattr(orderswb_import_flat, "parse_date", lambda x: pd.Timestamp(x))
+    monkeypatch.setattr(orderswb_import_flat.sqlite3, "connect", MagicMock())
+
+    with caplog.at_level("INFO"):
+        with pytest.raises(SystemExit):
+            orderswb_import_flat.main()
+
+    load_org.assert_called_once_with(sheet="OrgSheet")
+    load_period.assert_called_once_with(sheet="SettingsSheet")
+    assert "Using organizations sheet OrgSheet" in caplog.text
+    assert "Using settings sheet SettingsSheet" in caplog.text


### PR DESCRIPTION
## Summary
- Log and apply ORG_SHEET and SETTINGS_SHEET for all data-loading scripts
- Respect overridden sheet names via environment variables
- Test scripts with custom sheet names

## Testing
- `isort .`
- `black . -q --line-length 100`
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a181095fc8832aa31f32ed44e2d245