### PR TITLE
Refactor wb_spp_fetch entry point

### DIFF
--- a/src/finmodel/scripts/wb_spp_fetch.py
+++ b/src/finmodel/scripts/wb_spp_fetch.py
@@ -1,154 +1,155 @@
-def main():
-    #!/usr/bin/env python3
-    # -*- coding: utf-8 -*-
-    """
-    Обновляет таблицу wb_spp: берёт nmID из katalog, запрашивает
-    https://card.wb.ru/cards/v4/detail и сохраняет цены/скидки.
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Обновляет таблицу wb_spp: берёт nmID из katalog, запрашивает
+https://card.wb.ru/cards/v4/detail и сохраняет цены/скидки.
 
-    Запуск по умолчанию ищет finmodel.db на уровень выше
-    каталога, где лежит скрипт. Можно задать другой путь:
-        python wb_spp_fetch.py --db "C:\\path\\to\\finmodel.db"
-    """
+Запуск по умолчанию ищет finmodel.db на уровень выше
+каталога, где лежит скрипт. Можно задать другой путь:
+    python wb_spp_fetch.py --db "C:\\path\\to\\finmodel.db"
+"""
 
-    import argparse
-    import sqlite3
-    import time
-    from pathlib import Path
-    from typing import Optional, Tuple
+import argparse
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional, Tuple
 
-    import requests
+import requests
 
-    from finmodel.logger import get_logger
-    from finmodel.utils.paths import get_db_path
+from finmodel.logger import get_logger
+from finmodel.utils.paths import get_db_path
 
-    # ──────────────────────────────────────────────────────────────────────────────
-    # 1. Параметры и путь к базе
-    # ──────────────────────────────────────────────────────────────────────────────
-    logger = get_logger(__name__)
+logger = get_logger(__name__)
 
-    def parse_args() -> argparse.Namespace:
-        parser = argparse.ArgumentParser(add_help=False)
-        parser.add_argument(
-            "--db",
-            metavar="PATH",
-            help="Полный путь к finmodel.db (по умолчанию: ../finmodel.db).",
-        )
-        parser.add_argument("-h", "--help", action="help", help="Показать эту справку.")
-        return parser.parse_args()
+# ──────────────────────────────────────────────────────────────────────────────
+# 1. Константы API
+# ──────────────────────────────────────────────────────────────────────────────
+API_URL = "https://card.wb.ru/cards/v4/detail" "?appType=1&curr=rub&dest=-1257786&spp=0&nm={nm}"
+REQUEST_TIMEOUT = 10
+SLEEP_BETWEEN_CALLS = 0.2
+BATCH_SIZE = 100
 
-    def resolve_db_path(cli_path: str | None) -> Path:
-        if cli_path:
-            return Path(cli_path).expanduser().resolve()
-        return get_db_path()
+# ──────────────────────────────────────────────────────────────────────────────
+# 2. SQL
+# ──────────────────────────────────────────────────────────────────────────────
+CREATE_WB_SPP_SQL = """
+CREATE TABLE IF NOT EXISTS wb_spp (
+    nmID         INTEGER PRIMARY KEY,
+    priceU       INTEGER NOT NULL,
+    salePriceU   INTEGER NOT NULL,
+    sale_pct     INTEGER NOT NULL,
+    spp          INTEGER,            -- пока редко приходит → может быть NULL
+    updated_at   TEXT    NOT NULL
+);
+"""
 
+INSERT_SQL = """
+INSERT INTO wb_spp (nmID, priceU, salePriceU, sale_pct, spp, updated_at)
+VALUES (?, ?, ?, ?, ?, datetime('now'))
+ON CONFLICT(nmID) DO UPDATE SET
+    priceU       = excluded.priceU,
+    salePriceU   = excluded.salePriceU,
+    sale_pct     = excluded.sale_pct,
+    spp          = excluded.spp,
+    updated_at   = excluded.updated_at;
+"""
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 3. Вспомогательные функции
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def get_nm_ids(cur) -> list[int]:
+    cur.execute("SELECT nmID FROM katalog")
+    return [row[0] for row in cur.fetchall()]
+
+
+def fetch_card(nm_id: int) -> Tuple[int, int, int, int, Optional[int]]:
+    r = requests.get(API_URL.format(nm=nm_id), timeout=REQUEST_TIMEOUT)
+    r.raise_for_status()
+    product = r.json()["products"][0]
+    sizes = product.get("sizes", [])
+    if not sizes:
+        raise ValueError(f"no sizes data for nmID {nm_id}")
+
+    pb = sizes[0]["price"]
+    priceU, salePriceU = pb["basic"], pb["product"]
+    sale_pct = round((priceU - salePriceU) / priceU * 100)
+    spp = pb.get("spp")  # почти всегда None
+
+    return nm_id, priceU, salePriceU, sale_pct, spp
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--db",
+        metavar="PATH",
+        help="Полный путь к finmodel.db (по умолчанию: ../finmodel.db).",
+    )
+    parser.add_argument("-h", "--help", action="help", help="Показать эту справку.")
+    return parser.parse_args()
+
+
+def resolve_db_path(cli_path: str | None) -> Path:
+    if cli_path:
+        return Path(cli_path).expanduser().resolve()
+    return get_db_path()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 4. Основной поток
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
     args = parse_args()
-    DB_PATH: Path = resolve_db_path(args.db)
+    db_path: Path = resolve_db_path(args.db)
 
-    # ──────────────────────────────────────────────────────────────────────────────
-    # 2. Константы API
-    # ──────────────────────────────────────────────────────────────────────────────
-    API_URL = "https://card.wb.ru/cards/v4/detail" "?appType=1&curr=rub&dest=-1257786&spp=0&nm={nm}"
-    REQUEST_TIMEOUT = 10
-    SLEEP_BETWEEN_CALLS = 0.2
-    BATCH_SIZE = 100
+    logger.info("Используем базу: %s", db_path)
+    with sqlite3.connect(db_path) as con:
+        with con.cursor() as cur:
+            cur.execute(CREATE_WB_SPP_SQL)
 
-    # ──────────────────────────────────────────────────────────────────────────────
-    # 3. SQL
-    # ──────────────────────────────────────────────────────────────────────────────
-    CREATE_WB_SPP_SQL = """
-    CREATE TABLE IF NOT EXISTS wb_spp (
-        nmID         INTEGER PRIMARY KEY,
-        priceU       INTEGER NOT NULL,
-        salePriceU   INTEGER NOT NULL,
-        sale_pct     INTEGER NOT NULL,
-        spp          INTEGER,            -- пока редко приходит → может быть NULL
-        updated_at   TEXT    NOT NULL
-    );
-    """
+            try:
+                nm_ids = get_nm_ids(cur)
+            except sqlite3.OperationalError:
+                logger.error("❌ Таблица katalog не найдена. Создайте её и заполните nmID.")
+                return
 
-    INSERT_SQL = """
-    INSERT INTO wb_spp (nmID, priceU, salePriceU, sale_pct, spp, updated_at)
-    VALUES (?, ?, ?, ?, ?, datetime('now'))
-    ON CONFLICT(nmID) DO UPDATE SET
-        priceU       = excluded.priceU,
-        salePriceU   = excluded.salePriceU,
-        sale_pct     = excluded.sale_pct,
-        spp          = excluded.spp,
-        updated_at   = excluded.updated_at;
-    """
+            logger.info("Всего nmID: %s", len(nm_ids))
 
-    # ──────────────────────────────────────────────────────────────────────────────
-    # 4. Вспомогательные функции
-    # ──────────────────────────────────────────────────────────────────────────────
-    def get_nm_ids(cur) -> list[int]:
-        cur.execute("SELECT nmID FROM katalog")
-        return [row[0] for row in cur.fetchall()]
-
-    def fetch_card(nm_id: int) -> Tuple[int, int, int, int, Optional[int]]:
-        r = requests.get(API_URL.format(nm=nm_id), timeout=REQUEST_TIMEOUT)
-        r.raise_for_status()
-        product = r.json()["products"][0]
-        sizes = product.get("sizes", [])
-        if not sizes:
-            raise ValueError(f"no sizes data for nmID {nm_id}")
-
-        pb = sizes[0]["price"]
-        priceU, salePriceU = pb["basic"], pb["product"]
-        sale_pct = round((priceU - salePriceU) / priceU * 100)
-        spp = pb.get("spp")  # почти всегда None
-
-        return nm_id, priceU, salePriceU, sale_pct, spp
-
-    # ──────────────────────────────────────────────────────────────────────────────
-    # 5. Основной поток
-    # ──────────────────────────────────────────────────────────────────────────────
-    def main() -> None:
-        logger.info("Используем базу: %s", DB_PATH)
-        with sqlite3.connect(DB_PATH) as con:
-            with con.cursor() as cur:
-                cur.execute(CREATE_WB_SPP_SQL)
-
+            batch: list[tuple[int, int, int, int, Optional[int]]] = []
+            for i, nm in enumerate(nm_ids, 1):
                 try:
-                    nm_ids = get_nm_ids(cur)
-                except sqlite3.OperationalError:
-                    logger.error("❌ Таблица katalog не найдена. Создайте её и заполните nmID.")
-                    return
-
-                logger.info("Всего nmID: %s", len(nm_ids))
-
-                batch: list[tuple[int, int, int, int, Optional[int]]] = []
-                for i, nm in enumerate(nm_ids, 1):
-                    try:
-                        row = fetch_card(nm)
-                    except Exception as e:
-                        logger.warning("[%s/%s] nmID=%s ❌ %s", i, len(nm_ids), nm, e)
-                        time.sleep(SLEEP_BETWEEN_CALLS)
-                        continue
-
-                    batch.append(row)
-                    if len(batch) >= BATCH_SIZE:
-                        cur.executemany(INSERT_SQL, batch)
-                        batch.clear()
-
-                    logger.info(
-                        "[%s/%s] nmID=%s priceU=%s salePriceU=%s sale%%=%s spp=%s",
-                        i,
-                        len(nm_ids),
-                        row[0],
-                        row[1],
-                        row[2],
-                        row[3],
-                        row[4],
-                    )
+                    row = fetch_card(nm)
+                except Exception as e:
+                    logger.warning("[%s/%s] nmID=%s ❌ %s", i, len(nm_ids), nm, e)
                     time.sleep(SLEEP_BETWEEN_CALLS)
+                    continue
 
-                if batch:
+                batch.append(row)
+                if len(batch) >= BATCH_SIZE:
                     cur.executemany(INSERT_SQL, batch)
+                    batch.clear()
 
-        logger.info("Готово.")
+                logger.info(
+                    "[%s/%s] nmID=%s priceU=%s salePriceU=%s sale%%=%s spp=%s",
+                    i,
+                    len(nm_ids),
+                    row[0],
+                    row[1],
+                    row[2],
+                    row[3],
+                    row[4],
+                )
+                time.sleep(SLEEP_BETWEEN_CALLS)
 
-    if __name__ == "__main__":
-        main()
+            if batch:
+                cur.executemany(INSERT_SQL, batch)
+
+    logger.info("Готово.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- flatten wb_spp_fetch module to avoid nested definitions
- handle argument parsing and runtime logic within a single main()
- retain one module-level entry guard for direct CLI execution

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a19d3da75c832a9f23fab9e8028cad