### PR TITLE
Use nonlocal variable in fullstats throttle

### DIFF
--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -67,11 +67,11 @@ def main() -> None:
         except Exception:
             return True
 
-    # простой глобальный троттлер для всех POST
+    # простой троттлер для всех POST
     _last_post_ts = 0.0
 
     def throttle_fullstats():
-        global _last_post_ts
+        nonlocal _last_post_ts
         now = time.monotonic()
         wait = _last_post_ts + REQ_INTERVAL_SEC - now
         if wait > 0:


### PR DESCRIPTION
## Summary
- fix throttle helper to update last POST timestamp via nonlocal variable

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1b2977d6c832a81bd4b37c2c41236