### PR TITLE
Manage cursors explicitly in import scripts

### DIFF
--- a/src/finmodel/scripts/adv_campaigns_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_import_flat.py
@@ -44,7 +44,8 @@ def main() -> None:
     # --- Пересоздаём таблицу ---
     total_rows = 0
     with sqlite3.connect(db_path) as conn:
-        with conn.cursor() as cursor:
+        cursor = conn.cursor()
+        try:
             cursor.execute("DROP TABLE IF EXISTS AdvCampaignsFlat;")
             cursor.execute(
                 f"""
@@ -145,6 +146,8 @@ def main() -> None:
                     logger.warning("  Ошибка вставки: %s", e)
 
                 time.sleep(0.3)  # лимит 5 req/sec
+        finally:
+            cursor.close()
 
     logger.info("✅ Готово. Всего записей добавлено/обновлено: %s", total_rows)
 

--- a/src/finmodel/scripts/finotchet_import.py
+++ b/src/finmodel/scripts/finotchet_import.py
@@ -94,8 +94,8 @@ def main():
     ]
 
     with sqlite3.connect(db_path) as conn:
-        with conn.cursor() as cursor:
-
+        cursor = conn.cursor()
+        try:
             # --- Пересоздаём таблицу для плоских данных ---
             col_defs = (
                 "org_id INTEGER, "
@@ -135,6 +135,8 @@ def main():
             logger.info("✅ Всего записей обработано и вставлено: %s", total)
             if errors:
                 logger.warning("Были ошибки парсинга: %s записей не обработаны", errors)
+        finally:
+            cursor.close()
 
     logger.info("Готово! Таблица FinOtchetFlat содержит плоские данные для PowerBI/Excel.")
 

--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -123,17 +123,17 @@ def main():
         if not p.exists():
             raise SystemExit(f"SQLite файл не найден: {p}")
 
+        rows: list[sqlite3.Row] = []
         with sqlite3.connect(str(p)) as conn:
             conn.row_factory = sqlite3.Row
-            with conn.cursor() as cur:
-
+            cur = conn.cursor()
+            try:
                 # Если SQL не задан, пробуем два стандартных варианта
                 if not sql:
                     try_sql = [
                         "SELECT DISTINCT nmId AS nmId FROM katalog WHERE nmId IS NOT NULL",
                         "SELECT DISTINCT nm_id AS nmId FROM katalog WHERE nm_id IS NOT NULL",
                     ]
-                    rows = []
                     for q in try_sql:
                         try:
                             rows = cur.execute(q).fetchall()
@@ -149,6 +149,8 @@ def main():
                         )
                 else:
                     rows = cur.execute(sql).fetchall()
+            finally:
+                cur.close()
 
         nmids = [
             str(r["nmId"]).strip()


### PR DESCRIPTION
## Summary
- prevent unclosed SQLite cursors in adv_campaigns_import_flat, finotchet_import and wb_goods_prices_import_flat

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1ac365940832ab30cdf1a78b71cf7