### PR TITLE
Initialize logging in finotchet import script

### DIFF
--- a/src/finmodel/scripts/finotchet_import.py
+++ b/src/finmodel/scripts/finotchet_import.py
@@ -14,7 +14,6 @@ from finmodel.utils.settings import (
     parse_date,
 )
 
-setup_logging()
 logger = get_logger(__name__)
 
 
@@ -115,6 +114,8 @@ def make_http() -> requests.Session:
 
 
 def main() -> None:
+    setup_logging()
+
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60
     API_SLEEP = 60


### PR DESCRIPTION
## Summary
- configure logging at runtime in `finotchet_import`

## Testing
- `python -m compileall -q .`
- `pytest`
- `PYTHONPATH=src python -m finmodel.scripts.finotchet_import`


------
https://chatgpt.com/codex/tasks/task_e_68a1e8435fb4832a8c4abdd79999c784