### PR TITLE
Use context manager for ExcelFile

### DIFF
--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -81,15 +81,15 @@ def load_organizations(path: str | Path | None = None, sheet: str | None = None)
         logger.warning("Workbook %s not found", xls_path)
         return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
 
-    xls = pd.ExcelFile(xls_path)
-    logger.debug("Available sheets in %s: %s", xls_path, xls.sheet_names)
-    if sheet not in xls.sheet_names:
-        logger.warning(
-            "Sheet %s not found in %s. Available sheets: %s", sheet, xls_path, xls.sheet_names
-        )
-        return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
+    with pd.ExcelFile(xls_path) as xls:
+        logger.debug("Available sheets in %s: %s", xls_path, xls.sheet_names)
+        if sheet not in xls.sheet_names:
+            logger.warning(
+                "Sheet %s not found in %s. Available sheets: %s", sheet, xls_path, xls.sheet_names
+            )
+            return pd.DataFrame(columns=["id", "Организация", "Token_WB"])
 
-    df = xls.parse(sheet_name=sheet, header=None)
+        df = xls.parse(sheet_name=sheet, header=None)
     df = df.dropna(how="all")
     if df.empty:
         return pd.DataFrame(columns=["id", "Организация", "Token_WB"])


### PR DESCRIPTION
## Summary
- ensure `pd.ExcelFile` is closed by using a context manager in `load_organizations`
- extend tests to handle context manager and assert no `ResourceWarning`

## Testing
- `python -m isort src/finmodel/utils/settings.py`
- `python -m black src/finmodel/utils/settings.py`
- `python -m isort tests/utils/test_load_organizations.py`
- `python -m black tests/utils/test_load_organizations.py`
- `python -m compileall -q .`
- `pytest`
- `PYTHONPATH=src python - <<'PY'
import warnings
from pathlib import Path
import pandas as pd
from finmodel.utils.settings import load_organizations
import tempfile

with tempfile.TemporaryDirectory() as d:
    xls = Path(d) / 'orgs.xlsx'
    with pd.ExcelWriter(xls) as writer:
        pd.DataFrame({'id':[1], 'Организация':['Org'], 'Token_WB':['tok']}).to_excel(writer, sheet_name='НастройкиОрганизаций', index=False)
    with warnings.catch_warnings(record=True) as w:
        warnings.simplefilter('always', ResourceWarning)
        load_organizations(xls)
    print('resource warnings:', [str(warn.message) for warn in w])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a20b0fdd28832aa7878b572d46b94a