### PR TITLE
Initialize logging in script entrypoints

### DIFF
--- a/src/finmodel/scripts/adv_campaigns_details_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_details_import_flat.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import pandas as pd
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations
 
@@ -13,6 +13,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # --- Paths ---
     db_path = get_db_path()
 

--- a/src/finmodel/scripts/adv_campaigns_import_flat.py
+++ b/src/finmodel/scripts/adv_campaigns_import_flat.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import pandas as pd
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations
 
@@ -13,6 +13,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # --- Paths ---
     db_path = get_db_path()
 

--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -1,4 +1,8 @@
+from finmodel.logger import get_logger, setup_logging
+
+
 def main() -> None:
+    setup_logging()
     # -*- coding: utf-8 -*-
     import random
     import sqlite3
@@ -8,7 +12,6 @@ def main() -> None:
     import pandas as pd
     import requests
 
-    from finmodel.logger import get_logger
     from finmodel.utils.paths import get_db_path
     from finmodel.utils.settings import find_setting, load_organizations
 

--- a/src/finmodel/scripts/create_db.py
+++ b/src/finmodel/scripts/create_db.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import typer
 
+from finmodel.logger import setup_logging
+
 
 def create_db(db_path: Path, schema_path: Path) -> None:
     """Create an SQLite database using the provided schema."""
@@ -20,6 +22,7 @@ def main(
     schema: Path = typer.Option(Path("schema.sql"), help="Path to SQL schema file."),
 ) -> None:
     """Create an SQLite database from a schema file."""
+    setup_logging()
     create_db(db, schema)
     typer.echo(f"Database created at {db}")
 

--- a/src/finmodel/scripts/dump_schema.py
+++ b/src/finmodel/scripts/dump_schema.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import typer
 
+from finmodel.logger import setup_logging
+
 
 def dump_schema(db_path: Path, output: Path) -> None:
     """Dump SQL schema from the given database into a file."""
@@ -28,6 +30,7 @@ def main(
     output: Path = typer.Option(Path("schema.sql"), help="Path for output schema file."),
 ) -> None:
     """Dump SQL schema from an SQLite database."""
+    setup_logging()
     dump_schema(db, output)
     typer.echo(f"Schema dumped to {output}")
 

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -3,7 +3,7 @@ import time
 
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations
 
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # 📌 Paths
     db_path = get_db_path()
 

--- a/src/finmodel/scripts/nm_report_history_import.py
+++ b/src/finmodel/scripts/nm_report_history_import.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations
 
@@ -12,6 +12,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # --- Paths ---
     db_path = get_db_path()
 

--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -5,7 +5,7 @@ import time
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
@@ -13,6 +13,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # Максимальный размер страницы, заявленный в документации WB API
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
@@ -12,6 +12,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # ---------------- Paths ----------------
     db_path = get_db_path()
 

--- a/src/finmodel/scripts/paid_storage_import_incremental.py
+++ b/src/finmodel/scripts/paid_storage_import_incremental.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta
 
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations
 
@@ -12,6 +12,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # ---------- Paths ----------
     db_path = get_db_path()
 

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -5,7 +5,7 @@ import time
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
@@ -13,6 +13,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # Максимальный размер страницы, заявленный в документации WB API
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -5,7 +5,7 @@ import time
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
@@ -13,6 +13,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # Максимальный размер страницы, заявленный в документации WB API
     PAGE_LIMIT = 100_000
     REQUEST_TIMEOUT = 60

--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -1,4 +1,8 @@
+from finmodel.logger import get_logger, setup_logging
+
+
 def main():
+    setup_logging()
     # file: wb_spp_fetch.py  (v2)
     import csv
 
@@ -12,8 +16,6 @@ def main():
 
     import requests
     from requests.adapters import HTTPAdapter, Retry
-
-    from finmodel.logger import get_logger
 
     WB_ENDPOINT = "https://card.wb.ru/cards/v1/detail"
     CHUNK_SIZE = 100

--- a/src/finmodel/scripts/wb_spp_fetch.py
+++ b/src/finmodel/scripts/wb_spp_fetch.py
@@ -17,7 +17,7 @@ from typing import Optional, Tuple
 
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 
 logger = get_logger(__name__)
@@ -104,6 +104,7 @@ def resolve_db_path(cli_path: str | None) -> Path:
 
 
 def main() -> None:
+    setup_logging()
     args = parse_args()
     db_path: Path = resolve_db_path(args.db)
 

--- a/src/finmodel/scripts/wb_tariffs_box_import.py
+++ b/src/finmodel/scripts/wb_tariffs_box_import.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations, load_period, parse_date
 
@@ -11,6 +11,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # --- Paths ---
     db_path = get_db_path()
 

--- a/src/finmodel/scripts/wbtariffs_commission_import.py
+++ b/src/finmodel/scripts/wbtariffs_commission_import.py
@@ -2,7 +2,7 @@ import sqlite3
 
 import requests
 
-from finmodel.logger import get_logger
+from finmodel.logger import get_logger, setup_logging
 from finmodel.utils.paths import get_db_path
 from finmodel.utils.settings import find_setting, load_organizations
 
@@ -10,6 +10,7 @@ logger = get_logger(__name__)
 
 
 def main() -> None:
+    setup_logging()
     # --- Paths ---
     db_path = get_db_path()
 


### PR DESCRIPTION
## Summary
- ensure every script's `main()` initializes logging via `setup_logging`
- import `setup_logging` from `finmodel.logger` across all script modules

## Testing
- `isort src/finmodel/scripts/*.py`
- `black src/finmodel/scripts`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a20a023e14832ab59fd5dc4b8c92c4