### PR TITLE
Improve project root detection

### DIFF
--- a/src/finmodel/utils/paths.py
+++ b/src/finmodel/utils/paths.py
@@ -1,19 +1,29 @@
 from __future__ import annotations
 
 import os
+from importlib.resources import files
 from pathlib import Path
 
 
 def get_project_root() -> Path:
-    """Return the repository root.
+    """Return the project root directory.
 
     The location can be overridden by the ``FINMODEL_PROJECT_ROOT`` environment
-    variable. Otherwise the path is resolved relative to this file.
+    variable. Otherwise the function looks for repository markers such as
+    ``.git`` or ``pyproject.toml`` starting from this file's location. If no
+    marker is found (e.g. when running from an installed package), the package
+    location itself is used.
     """
     env_root = os.getenv("FINMODEL_PROJECT_ROOT")
     if env_root:
         return Path(env_root).expanduser().resolve()
-    return Path(__file__).resolve().parents[3]
+
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        if (parent / ".git").exists() or (parent / "pyproject.toml").exists():
+            return parent
+
+    return Path(files("finmodel")).resolve()
 
 
 def get_db_path() -> Path:

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib
+import shutil
+import sys
+from importlib import resources
+from pathlib import Path
+
+
+def test_get_project_root_development():
+    from finmodel.utils.paths import get_project_root
+
+    root = get_project_root()
+    assert (root / "pyproject.toml").exists()
+
+
+def test_get_project_root_installed(tmp_path, monkeypatch):
+    package_src = Path(__file__).resolve().parents[2] / "src" / "finmodel"
+    site_packages = tmp_path / "site-packages"
+    shutil.copytree(package_src, site_packages / "finmodel")
+
+    monkeypatch.syspath_prepend(str(site_packages))
+    monkeypatch.delenv("FINMODEL_PROJECT_ROOT", raising=False)
+
+    sys.modules.pop("finmodel", None)
+    sys.modules.pop("finmodel.utils", None)
+    sys.modules.pop("finmodel.utils.paths", None)
+
+    mod = importlib.import_module("finmodel.utils.paths")
+    importlib.reload(mod)
+
+    root = mod.get_project_root()
+    assert root == Path(resources.files("finmodel")).resolve()


### PR DESCRIPTION
## Summary
- make project root detection search for repo markers and fallback to package location
- add tests verifying project root detection in development and installed contexts

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20f331ec8832abdf16c8e2e1e29f0