### PR TITLE
Handle database connection failure gracefully

### DIFF
--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -38,12 +38,15 @@ def main() -> None:
         return
 
     # 📌 Подключение к базе
+    conn = None
     try:
         conn = sqlite3.connect(db_path, timeout=10)
         cursor = conn.cursor()
     except sqlite3.OperationalError as e:
         logger.error("Ошибка подключения к базе: %s", e)
-        exit(1)
+        if conn is not None:
+            conn.close()
+        raise SystemExit(1)
 
     # 📌 Пересоздание таблицы с нужными столбцами
     cursor.execute("DROP TABLE IF EXISTS katalog;")


### PR DESCRIPTION
## Summary
- ensure katalog script closes open connections and exits with SystemExit on database errors

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a211c628b8832a9e706c00647d0be0