### PR TITLE
Refactor adv_fullstats_import_flat imports

### DIFF
--- a/src/finmodel/scripts/adv_fullstats_import_flat.py
+++ b/src/finmodel/scripts/adv_fullstats_import_flat.py
@@ -1,20 +1,19 @@
+# -*- coding: utf-8 -*-
+import random
+import sqlite3
+import time
+from datetime import datetime, timedelta
+
+import pandas as pd
+import requests
+
 from finmodel.logger import get_logger, setup_logging
+from finmodel.utils.paths import get_db_path
+from finmodel.utils.settings import find_setting, load_organizations
 
 
 def main() -> None:
     setup_logging()
-    # -*- coding: utf-8 -*-
-    import random
-    import sqlite3
-    import time
-    from datetime import datetime, timedelta
-
-    import pandas as pd
-    import requests
-
-    from finmodel.utils.paths import get_db_path
-    from finmodel.utils.settings import find_setting, load_organizations
-
     logger = get_logger(__name__)
 
     # ---------- Paths ----------

--- a/tests/scripts/test_adv_fullstats_import_flat.py
+++ b/tests/scripts/test_adv_fullstats_import_flat.py
@@ -16,7 +16,9 @@ from finmodel.scripts import adv_fullstats_import_flat
 def test_main_runs_without_nameerror(monkeypatch):
     df = pd.DataFrame([{"id": "1", "Организация": "Org", "Token_WB": "token"}])
 
-    monkeypatch.setattr("finmodel.utils.settings.load_organizations", lambda sheet=None: df)
+    monkeypatch.setattr(
+        adv_fullstats_import_flat, "load_organizations", lambda sheet=None: df, raising=False
+    )
     monkeypatch.setattr(
         adv_fullstats_import_flat,
         "get_campaign_ids_from_api",


### PR DESCRIPTION
## Summary
- Move encoding declaration and all imports to the top of `adv_fullstats_import_flat`
- Start `main` with runtime logic and update tests for new import locations

## Testing
- `python -m compileall -q .`
- `pytest`
- `PYTHONPATH=src python -m finmodel.scripts.adv_fullstats_import_flat` *(fails: Workbook /workspace/Finmodel-2.0/Настройки.xlsm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21317f130832a8459ed097126276c