### PR TITLE
Add __init__ for scripts package

### DIFF
--- a/src/finmodel/scripts/__init__.py
+++ b/src/finmodel/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line script entry points for finmodel."""


### PR DESCRIPTION
## Summary
- make `finmodel.scripts` a regular package by adding `__init__.py`
- verify script modules like `katalog` remain importable

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21505f15c832ab4e902226f2a1381