### PR TITLE
Persist FinOtchet records without truncation

### DIFF
--- a/tests/scripts/test_finotchet_import.py
+++ b/tests/scripts/test_finotchet_import.py
@@ -72,15 +72,9 @@ def test_finotchet_inserts_rows_and_stops_on_empty_response():
         load_orgs.assert_called_once_with(sheet="OrgSheet")
         load_period.assert_called_once_with(sheet="SettingsSheet")
 
-        fin_calls = [
-            c for c in mock_cursor.executemany.call_args_list if "FinOtchet VALUES" in c.args[0]
-        ]
-        flat_calls = [
-            c for c in mock_cursor.executemany.call_args_list if "FinOtchetFlat" in c.args[0]
-        ]
+        fin_calls = [c for c in mock_cursor.executemany.call_args_list if "FinOtchet" in c.args[0]]
         assert len(fin_calls) == 2
-        assert len(flat_calls) == 2
-        for c in fin_calls + flat_calls:
+        for c in fin_calls:
             assert c.args[1]
 
         assert mock_get.call_count == 3


### PR DESCRIPTION
## Summary
- store Wildberries finance report data in a single `FinOtchet` table with a composite primary key
- upsert rows on import instead of dropping data

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a237d11258832aa5db2430438a383b