### PR TITLE
Enable incremental SalesWB import with optional full reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ finmodel dump_schema --db finmodel.db --output schema.sql
    finmodel saleswb_import_flat
    # или явно через модуль
    python -m finmodel.cli saleswb_import_flat
+   # полная перезагрузка (удаляет существующие продажи)
+   finmodel saleswb_import_flat --full-reload
    ```
    Старый формат `python -m finmodel.scripts.*` по-прежнему работает для совместимости.
 


### PR DESCRIPTION
## Summary
- Preserve SalesWBFlat by creating it if missing and add `--full-reload` flag to clear existing rows when requested
- Resume imports per organization using the latest `lastChangeDate`
- Document full reload usage in README

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2cdbb00d8832a8f57f7f599cfe976