### PR TITLE
Add incremental reload for Wildberries orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ docker run --rm -e FINMODEL_SCRIPT=finmodel.scripts.orderswb_import_flat \
   finmodel
 ```
 
+Флаг `--full-reload` перезагружает данные заново, начиная с `ПериодНачало`:
+
+```bash
+docker run --rm -e FINMODEL_SCRIPT=finmodel.scripts.orderswb_import_flat \
+  -v $(pwd)/config.yml:/app/config.yml \
+  -v $(pwd)/Настройки.xlsm:/app/Настройки.xlsm \
+  -v $(pwd)/finmodel.db:/app/finmodel.db \
+  finmodel -- --full-reload
+```
+
 Чтобы использовать PostgreSQL вместо SQLite, поднимите приложение через `docker-compose`:
 
 ```yaml


### PR DESCRIPTION
## Summary
- preserve OrdersWBFlat table and create with IF NOT EXISTS
- resume WB orders import from last loaded record, with optional --full-reload
- document full reload option in README

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2cdbd8c08832a90c49435e6df3adb