### PR TITLE
Normalize article codes across import scripts

### DIFF
--- a/src/finmodel/scripts/finotchet_import.py
+++ b/src/finmodel/scripts/finotchet_import.py
@@ -95,6 +95,7 @@ WB_FIELDS = [
     "cashback_amount",
     "cashback_discount",
 ]
+LOWER_FIELDS = {"sa_name"}
 
 
 def make_http() -> requests.Session:
@@ -197,7 +198,16 @@ def main() -> None:
 
             rows = []
             for rec in data:
-                rows.append([org_id, org_name] + [str(rec.get(f, "")) for f in WB_FIELDS])
+                rows.append(
+                    [
+                        org_id,
+                        org_name,
+                    ]
+                    + [
+                        str(rec.get(f, "")).lower() if f in LOWER_FIELDS else str(rec.get(f, ""))
+                        for f in WB_FIELDS
+                    ]
+                )
 
             try:
                 placeholders = ",".join(["?"] * (2 + len(WB_FIELDS)))

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -136,7 +136,7 @@ def main() -> None:
                                 card.get("subjectID"),
                                 card.get("subjectName"),
                                 card.get("brand"),
-                                card.get("vendorCode"),
+                                str(card.get("vendorCode", "")).lower(),
                                 techSize,
                                 sku,
                                 chrtID,

--- a/src/finmodel/scripts/nm_report_history_import.py
+++ b/src/finmodel/scripts/nm_report_history_import.py
@@ -164,7 +164,7 @@ def main() -> None:
                 for item in data:
                     nm = str(item.get("nmID", ""))
                     imtName = str(item.get("imtName", ""))
-                    vendorCode = str(item.get("vendorCode", ""))
+                    vendorCode = str(item.get("vendorCode", "")).lower()
                     history = item.get("history", []) or []
                     for h in history:
                         rows.append(

--- a/src/finmodel/scripts/orderswb_import_flat.py
+++ b/src/finmodel/scripts/orderswb_import_flat.py
@@ -19,7 +19,7 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Reload data from period start ignoring existing rows",
     )
-    args = parser.parse_args(argv)
+    args = parser.parse_args(argv or [])
 
     setup_logging()
     # Максимальный размер страницы, заявленный в документации WB API
@@ -79,6 +79,7 @@ def main(argv: list[str] | None = None) -> None:
         "gNumber",
         "srid",
     ]
+    LOWER_FIELDS = {"supplierArticle"}
 
     # --- Подключение к базе и создание плоской таблицы ---
     conn = sqlite3.connect(db_path)
@@ -180,7 +181,13 @@ def main(argv: list[str] | None = None) -> None:
             # Распаковка
             rows = []
             for rec in data:
-                flat = [org_id, org_name] + [str(rec.get(f, "")) for f in ORDER_FIELDS]
+                flat = [
+                    org_id,
+                    org_name,
+                ] + [
+                    str(rec.get(f, "")).lower() if f in LOWER_FIELDS else str(rec.get(f, ""))
+                    for f in ORDER_FIELDS
+                ]
                 rows.append(flat)
             try:
                 placeholders = ",".join(["?"] * (2 + len(ORDER_FIELDS)))

--- a/src/finmodel/scripts/paid_storage_import_flat.py
+++ b/src/finmodel/scripts/paid_storage_import_flat.py
@@ -281,7 +281,7 @@ def main() -> None:
                             str(rec.get("barcode", "")),
                             str(rec.get("subject", "")),
                             str(rec.get("brand", "")),
-                            str(rec.get("vendorCode", "")),
+                            str(rec.get("vendorCode", "")).lower(),
                             str(rec.get("nmId", "")),
                             str(rec.get("volume", "")),
                             str(rec.get("calcType", "")),

--- a/src/finmodel/scripts/paid_storage_import_incremental.py
+++ b/src/finmodel/scripts/paid_storage_import_incremental.py
@@ -262,7 +262,7 @@ def main() -> None:
                             str(rec.get("barcode", "")),
                             str(rec.get("subject", "")),
                             str(rec.get("brand", "")),
-                            str(rec.get("vendorCode", "")),
+                            str(rec.get("vendorCode", "")).lower(),
                             str(rec.get("nmId", "")),
                             str(rec.get("volume", "")),
                             str(rec.get("calcType", "")),

--- a/src/finmodel/scripts/saleswb_import_flat.py
+++ b/src/finmodel/scripts/saleswb_import_flat.py
@@ -83,6 +83,7 @@ def main() -> None:
         "gNumber",
         "srid",
     ]
+    LOWER_FIELDS = {"supplierArticle"}
 
     # --- Connect to DB and create flat table ---
     conn = sqlite3.connect(db_path)
@@ -168,7 +169,13 @@ def main() -> None:
             # Unpack
             rows = []
             for rec in data:
-                flat = [org_id, org_name] + [str(rec.get(f, "")) for f in SALES_FIELDS]
+                flat = [
+                    org_id,
+                    org_name,
+                ] + [
+                    str(rec.get(f, "")).lower() if f in LOWER_FIELDS else str(rec.get(f, ""))
+                    for f in SALES_FIELDS
+                ]
                 rows.append(flat)
             try:
                 placeholders = ",".join(["?"] * (2 + len(SALES_FIELDS)))

--- a/src/finmodel/scripts/stockswb_import_flat.py
+++ b/src/finmodel/scripts/stockswb_import_flat.py
@@ -61,6 +61,7 @@ def main() -> None:
         "isRealization",
         "SCCode",
     ]
+    LOWER_FIELDS = {"supplierArticle"}
 
     # --- Пересоздание таблицы ---
     conn = sqlite3.connect(db_path)
@@ -135,7 +136,13 @@ def main() -> None:
             # Распаковка
             rows = []
             for rec in data:
-                flat = [org_id, org_name] + [str(rec.get(f, "")) for f in STOCKS_FIELDS]
+                flat = [
+                    org_id,
+                    org_name,
+                ] + [
+                    str(rec.get(f, "")).lower() if f in LOWER_FIELDS else str(rec.get(f, ""))
+                    for f in STOCKS_FIELDS
+                ]
                 rows.append(flat)
             try:
                 placeholders = ",".join(["?"] * (2 + len(STOCKS_FIELDS)))


### PR DESCRIPTION
## Summary
- ensure `supplierArticle`, `sa_name`, and `vendorCode` values are stored in lowercase across import scripts
- guard orders import argument parsing from extraneous CLI flags

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2eab40858832a9166a00897ef1262