### PR TITLE
Simplify CLI for goods prices import

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,19 +210,22 @@ finmodel finotchet_import
 ### wb_goods_prices_import_flat
 
 Скрипт `wb_goods_prices_import_flat` запрашивает цены и скидки для списка
-товаров Wildberries по их `nmId` и записывает результат в таблицу `dbo.spp`
-через ODBC.
+товаров Wildberries по их `nmId`.
 
-Обязательные аргументы:
+Источник `nmId` задаётся одним из аргументов:
 
-- `--dsn` — строка подключения ODBC к базе данных.
-- `nmId` — один или несколько артикулов, передаются позиционными
-  параметрами.
+- `--csv` — CSV‑файл с колонкой `nmId` (имя можно изменить через `--col`);
+- `--txt` — текстовый файл со списком `nmId`;
+- `--sqlite` — SQLite‑файл, из которого `nmId` извлекаются SQL‑запросом
+  (`--sql`).
+
+Результаты можно сохранить в CSV (`--out-csv`), SQLite (`--out-sqlite`) или
+таблицу базы данных через ODBC (`--out-odbc`, `--odbc-table`).
 
 Пример запуска:
 
 ```bash
-python -m finmodel.scripts.wb_goods_prices_import_flat --dsn "DSN=Finmodel" 12345 67890
+python -m finmodel.scripts.wb_goods_prices_import_flat --csv nmids.csv --out-sqlite finmodel.db
 ```
 
 ## Docker

--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -2,76 +2,13 @@
 
 from __future__ import annotations
 
-
-def main():
-    setup_logging()
-    # file: wb_spp_fetch.py  (v2)
-    import argparse
-    import csv
-    import sqlite3
-    import sys
-    import time
-    from datetime import datetime, timezone
-    from pathlib import Path
-    from typing import Any, Dict, Iterable, List
-
-    import requests
-    from requests.adapters import HTTPAdapter, Retry
-
-    WB_ENDPOINT = "https://card.wb.ru/cards/v1/detail"
-    CHUNK_SIZE = 100
-    TIMEOUT = 15
-    SLEEP_BETWEEN_BATCHES_SEC = 0.4
-
-    def iter_chunks(lst: List[str], size: int) -> Iterable[List[str]]:
-        for i in range(0, len(lst), size):
-            yield lst[i : i + size]
-
-    def make_http() -> requests.Session:
-        s = requests.Session()
-        retries = Retry(
-            total=5,
-            read=5,
-            connect=5,
-            backoff_factor=0.5,
-            status_forcelist=(429, 500, 502, 503, 504),
-            allowed_methods=frozenset(["GET"]),
-        )
-        s.headers.update(
-            {"Accept": "application/json", "User-Agent": "WB-SPP-Fetcher/1.0 (+PowerBI)"}
-        )
-        s.mount("https://", HTTPAdapter(max_retries=retries))
-        s.mount("http://", HTTPAdapter(max_retries=retries))
-        return s
-
-    logger = get_logger(__name__)
-
-    def fetch_batch(http: requests.Session, ids: List[str]) -> List[Dict[str, Any]]:
-        ids_clean = [str(x).strip() for x in ids if str(x).strip()]
-        if not ids_clean:
-            return []
-        params = {"appType": 1, "curr": "rub", "dest": -1257786, "nm": ";".join(ids_clean)}
-        r = http.get(WB_ENDPOINT, params=params, timeout=TIMEOUT)
-        r.raise_for_status()
-        payload = r.json()
-        products = (payload or {}).get("data", {}).get("products", []) or []
-
-        out = []
-        for p in products:
-            out.append(
-                {
-                    "nmId": str(p.get("id")) if p.get("id") is not None else None,
-                    "priceU": p.get("priceU") if isinstance(p.get("priceU"), int) else None,
-                    "salePriceU": (
-                        p.get("salePriceU") if isinstance(p.get("salePriceU"), int) else None
-                    ),
-                    "sale": (
-                        float(p.get("sale")) if isinstance(p.get("sale"), (int, float)) else None
-                    ),
-                }
-            )
-        return out
-
+import argparse
+import csv
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
@@ -282,6 +219,45 @@ def write_to_db_odbc(rows: List[Dict[str, Any]], dsn: str, table: str = "dbo.spp
     return inserted
 
 
+def write_to_sqlite(
+    db_path: str, rows: List[Dict[str, Any]], table: str = "WBGoodsPricesFlat"
+) -> int:
+    if not rows:
+        logger.warning("Нет строк для записи в SQLite — пропускаю.")
+        return 0
+    p = Path(db_path)
+    conn = sqlite3.connect(str(p))
+    cur = conn.cursor()
+    cur.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table} (
+            nmId TEXT PRIMARY KEY,
+            priceU INTEGER,
+            salePriceU INTEGER,
+            sale REAL,
+            price_rub REAL,
+            salePrice_rub REAL,
+            discount_total_pct REAL,
+            spp_pct_approx REAL,
+            updated_at_utc TEXT
+        )
+        """
+    )
+    cur.executemany(
+        f"""
+        INSERT OR REPLACE INTO {table}
+        (nmId, priceU, salePriceU, sale, price_rub, salePrice_rub, discount_total_pct, spp_pct_approx, updated_at_utc)
+        VALUES (:nmId, :priceU, :salePriceU, :sale, :price_rub, :salePrice_rub, :discount_total_pct, :spp_pct_approx, :updated_at_utc)
+        """,
+        rows,
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+    logger.info("Записано строк в SQLite: %s", len(rows))
+    return len(rows)
+
+
 def import_prices(nmids: List[str], dsn: str, http: requests.Session | None = None) -> int:
     http = http or make_http()
     all_rows: List[Dict[str, Any]] = []
@@ -292,57 +268,9 @@ def import_prices(nmids: List[str], dsn: str, http: requests.Session | None = No
     return write_to_db_odbc(all_rows, dsn)
 
 
-def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("nmids", nargs="+", help="Список nmId товаров")
-    parser.add_argument("--dsn", required=True, help="Строка подключения ODBC")
-    return parser.parse_args(argv)
-
-
 def main(argv: List[str] | None = None) -> None:
     setup_logging()
-    args = parse_args(argv)
-    import_prices(args.nmids, dsn=args.dsn)
-
-    def write_to_sqlite(
-        db_path: str, rows: List[Dict[str, Any]], table: str = "WBGoodsPricesFlat"
-    ) -> int:
-        if not rows:
-            logger.warning("Нет строк для записи в SQLite — пропускаю.")
-            return 0
-        p = Path(db_path)
-        conn = sqlite3.connect(str(p))
-        cur = conn.cursor()
-        cur.execute(
-            f"""
-            CREATE TABLE IF NOT EXISTS {table} (
-                nmId TEXT PRIMARY KEY,
-                priceU INTEGER,
-                salePriceU INTEGER,
-                sale REAL,
-                price_rub REAL,
-                salePrice_rub REAL,
-                discount_total_pct REAL,
-                spp_pct_approx REAL,
-                updated_at_utc TEXT
-            )
-            """
-        )
-        cur.executemany(
-            f"""
-            INSERT OR REPLACE INTO {table}
-            (nmId, priceU, salePriceU, sale, price_rub, salePrice_rub, discount_total_pct, spp_pct_approx, updated_at_utc)
-            VALUES (:nmId, :priceU, :salePriceU, :sale, :price_rub, :salePrice_rub, :discount_total_pct, :spp_pct_approx, :updated_at_utc)
-            """,
-            rows,
-        )
-        conn.commit()
-        cur.close()
-        conn.close()
-        logger.info("Записано строк в SQLite: %s", len(rows))
-        return len(rows)
-
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     src_group = parser.add_mutually_exclusive_group(required=True)
     src_group.add_argument("--csv", help="CSV-файл с колонкой nmId")
     src_group.add_argument("--txt", help="TXT-файл со списком nmId")
@@ -357,7 +285,7 @@ def main(argv: List[str] | None = None) -> None:
         "--odbc-table", default="WBGoodsPricesFlat", help="Таблица для записи через ODBC"
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not (args.out_csv or args.out_sqlite or args.out_odbc):
         parser.error("Нужно указать хотя бы один вывод: --out-csv, --out-sqlite или --out-odbc")


### PR DESCRIPTION
## Summary
- use a single extended CLI parser in `wb_goods_prices_import_flat`
- update README for new `wb_goods_prices_import_flat` usage

## Testing
- `isort src/finmodel/scripts/wb_goods_prices_import_flat.py tests/scripts/test_wb_goods_prices_import_flat.py`
- `black src/finmodel/scripts/wb_goods_prices_import_flat.py tests/scripts/test_wb_goods_prices_import_flat.py`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a307e36894832aadd8d790fc481170