### PR TITLE
Handle None values explicitly in price metrics

### DIFF
--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -73,6 +73,9 @@ def main():
         return out
 
 
+import time
+from datetime import datetime, timezone
+
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
@@ -139,13 +142,11 @@ def calc_metrics(row: Dict[str, Any]) -> Dict[str, Any]:
 
     discount_total_pct = (
         (1 - (sale_price_u / price_u)) * 100.0
-        if price_u and sale_price_u and price_u != 0
+        if price_u is not None and sale_price_u is not None and price_u != 0
         else None
     )
     spp_pct_approx = (
-        (discount_total_pct - sale)
-        if (discount_total_pct is not None and sale is not None)
-        else None
+        discount_total_pct - sale if discount_total_pct is not None and sale is not None else None
     )
 
     return {


### PR DESCRIPTION
## Summary
- guard against missing price values when computing discount metrics
- expose `time` and `datetime` at module level

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a307e531a8832abeca54a1213b6e9e