### PR TITLE
Update goods price importer for new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ finmodel dump_schema --db finmodel.db --output schema.sql
    Скрипт `wb_goods_prices_import_flat` загружает текущие цены товаров по списку `nmId`:
 
    ```bash
-   finmodel wb_goods_prices_import_flat --csv nmids.csv --out-sqlite finmodel.db
+   finmodel wb_goods_prices_import_flat --csv nmids.csv --out-sqlite finmodel.db --api-key YOUR_KEY
    ```
 
 ## Конфигурация
@@ -217,7 +217,7 @@ finmodel finotchet_import
 Пример запуска:
 
 ```bash
-finmodel wb_goods_prices_import_flat --csv nmids.csv --out-odbc "DSN=Finmodel"
+finmodel wb_goods_prices_import_flat --csv nmids.csv --out-odbc "DSN=Finmodel" --api-key YOUR_KEY
 ```
 
 ## Docker

--- a/tests/scripts/test_wb_goods_prices_import_flat.py
+++ b/tests/scripts/test_wb_goods_prices_import_flat.py
@@ -17,7 +17,14 @@ def test_import_prices_inserts_rows(monkeypatch):
             "data": {"products": [{"id": 123, "priceU": 1000, "salePriceU": 900, "sale": 10}]}
         },
     )
-    fake_session = SimpleNamespace(get=lambda url, params, timeout: fake_response)
+
+    def fake_get(url, params, timeout):
+        assert params["limit"] == 1
+        assert params["offset"] == 0
+        assert params["filterNmID"] == "123"
+        return fake_response
+
+    fake_session = SimpleNamespace(get=fake_get)
 
     rows: list[tuple] = []
 


### PR DESCRIPTION
## Summary
- switch goods price importer to the new discounts-prices API
- support limit/offset and optional nmId filtering
- allow passing API key via `--api-key`

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a313a004c0832aa2a99983671f78ae