### PR TITLE
Log API error responses in WB goods prices import

### DIFF
--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -539,6 +539,8 @@ def main(argv: Optional[List[str]] = None) -> None:
                             batch = fetch_batch(http, nm_id=nm)
                         except requests.exceptions.HTTPError as exc:
                             logger.warning("HTTP error for nmID %s: %s", nm, exc)
+                            if exc.response is not None:
+                                logger.warning("Response body: %s", exc.response.text)
                             continue
                         except Exception:
                             logger.exception("Ошибка при запросе nmID: %s", nm)


### PR DESCRIPTION
## Summary
- warn with response body when WB API returns an HTTP error

## Testing
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a400c25050832aa44c6fddb727a738