### PR TITLE
Include limit parameter for nmID price fetch

### DIFF
--- a/src/finmodel/scripts/wb_goods_prices_import_flat.py
+++ b/src/finmodel/scripts/wb_goods_prices_import_flat.py
@@ -65,6 +65,7 @@ def fetch_batch(
     params: Dict[str, Any] = {}
     if nm_id is not None:
         params["filterNmID"] = nm_id
+        params["limit"] = limit
     else:
         params.update({"limit": limit, "offset": offset})
 

--- a/tests/scripts/test_wb_goods_prices_import_flat.py
+++ b/tests/scripts/test_wb_goods_prices_import_flat.py
@@ -38,7 +38,7 @@ def test_import_prices_inserts_rows(monkeypatch):
     )
 
     def fake_get(url, params, timeout):
-        assert params == {"filterNmID": "123"}
+        assert params == {"filterNmID": "123", "limit": script.PAGE_LIMIT}
         return fake_response
 
     fake_session = SimpleNamespace(get=fake_get)


### PR DESCRIPTION
## Summary
- add limit param when fetching goods prices by nmID
- adjust test to expect limit alongside filterNmID

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a40d3a3884832a8fdb71a5d8f25401