### PR TITLE
Include allowedCategoriesOnly filter in katalog pagination

### DIFF
--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -96,7 +96,12 @@ def main() -> None:
         nmID = None
 
         while has_more:
-            payload = {"settings": {"cursor": {"limit": 100}, "filter": {"withPhoto": -1}}}
+            payload = {
+                "settings": {
+                    "cursor": {"limit": 100},
+                    "filter": {"withPhoto": -1, "allowedCategoriesOnly": False},
+                }
+            }
 
             if updatedAt and nmID:
                 payload["settings"]["cursor"].update({"updatedAt": updatedAt, "nmID": nmID})


### PR DESCRIPTION
## Summary
- include `allowedCategoriesOnly: False` in katalog pagination payload so all categories are fetched

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a58556ef04832a8b70881c6889968c