### PR TITLE
Add snapshot date to goods prices export

### DIFF
--- a/tests/scripts/test_wb_goods_prices_import_flat.py
+++ b/tests/scripts/test_wb_goods_prices_import_flat.py
@@ -123,7 +123,15 @@ def test_main_uses_xls_tokens(tmp_path, monkeypatch):
 
     monkeypatch.setattr(script, "make_http", fake_make_http)
     monkeypatch.setattr(script, "fetch_batch", fake_fetch_batch)
-    monkeypatch.setattr(script, "calc_metrics", lambda r: r)
+    monkeypatch.setattr(
+        script,
+        "calc_metrics",
+        lambda r: {
+            **r,
+            "snapshot_date": "2024-01-01",
+            "updated_at_utc": "2024-01-01T00:00:00",
+        },
+    )
     monkeypatch.setattr(script.time, "sleep", lambda x: None)
 
     script.main([])
@@ -155,7 +163,15 @@ def test_main_skips_nmids_on_http_error(monkeypatch, caplog):
         ]
 
     monkeypatch.setattr(script, "fetch_batch", fake_fetch_batch)
-    monkeypatch.setattr(script, "calc_metrics", lambda r: r)
+    monkeypatch.setattr(
+        script,
+        "calc_metrics",
+        lambda r: {
+            **r,
+            "snapshot_date": "2024-01-01",
+            "updated_at_utc": "2024-01-01T00:00:00",
+        },
+    )
     monkeypatch.setattr(script.time, "sleep", lambda x: None)
 
     collected = []


### PR DESCRIPTION
## Summary
- record snapshot date in calc_metrics and include it across CSV, SQLite and ODBC sinks
- extend WBGoodsPricesFlat schema with snapshot_date in primary key and use INSERT OR REPLACE
- update tests for new snapshot_date field

## Testing
- `isort src/finmodel/scripts/wb_goods_prices_import_flat.py tests/scripts/test_wb_goods_prices_import_flat.py`
- `black src/finmodel/scripts/wb_goods_prices_import_flat.py tests/scripts/test_wb_goods_prices_import_flat.py`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7440e5290832a998e1ee8d5b3b811