### PR TITLE
Add snapshot_date column and migration for katalog table

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Python-утилиты для импорта и анализа финансовы
 finmodel dump_schema --db finmodel.db --output schema.sql
 ```
 
+### Миграция `katalog`
+
+Чтобы добавить колонку `snapshot_date` и новый составной первичный ключ в существующую таблицу `katalog`, выполните SQL-скрипт миграции. Предварительно сделайте резервную копию базы данных.
+
+```bash
+# для SQLite
+sqlite3 finmodel.db < migrations/20240706_add_snapshot_date_to_katalog.sql
+
+# для PostgreSQL
+psql -d finmodel -f migrations/20240706_add_snapshot_date_to_katalog.sql
+```
+
+Скрипт создаёт таблицу `katalog_new`, переносит в неё текущие строки с датой снимка `snapshot_date` равной текущей, а затем переименовывает таблицу обратно в `katalog`.
+
 4. Скопируйте `config.example.yml` в `config.yml` и заполните диапазоны дат.
    Файл `Настройки.xlsm` с колонками `id`, `Организация` и `Token_WB` должен
    находиться в корне проекта рядом с базой данных `finmodel.db`. Переменные

--- a/migrations/20240706_add_snapshot_date_to_katalog.sql
+++ b/migrations/20240706_add_snapshot_date_to_katalog.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+CREATE TABLE katalog_new (
+    org_id INTEGER,
+    Организация TEXT,
+    nmID INTEGER,
+    imtID INTEGER,
+    nmUUID TEXT,
+    subjectID INTEGER,
+    subjectName TEXT,
+    brand TEXT,
+    vendorCode TEXT,
+    techSize TEXT,
+    sku TEXT,
+    chrtID INTEGER,
+    createdAt TEXT,
+    updatedAt TEXT,
+    snapshot_date TEXT NOT NULL DEFAULT (CURRENT_DATE),
+    PRIMARY KEY (org_id, chrtID, snapshot_date)
+);
+
+INSERT INTO katalog_new (
+    org_id, Организация, nmID, imtID, nmUUID,
+    subjectID, subjectName, brand, vendorCode,
+    techSize, sku, chrtID, createdAt, updatedAt, snapshot_date
+)
+SELECT
+    org_id, Организация, nmID, imtID, nmUUID,
+    subjectID, subjectName, brand, vendorCode,
+    techSize, sku, chrtID, createdAt, updatedAt, CURRENT_DATE
+FROM katalog;
+
+DROP TABLE katalog;
+ALTER TABLE katalog_new RENAME TO katalog;
+
+COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -13,7 +13,8 @@ CREATE TABLE katalog (
     chrtID INTEGER,
     createdAt TEXT,
     updatedAt TEXT,
-    PRIMARY KEY (org_id, chrtID)
+    snapshot_date TEXT NOT NULL DEFAULT (CURRENT_DATE),
+    PRIMARY KEY (org_id, chrtID, snapshot_date)
 );
 
 CREATE TABLE FinOtchet (org_id INTEGER, Организация TEXT, realizationreport_id TEXT, date_from TEXT, date_to TEXT, create_dt TEXT, currency_name TEXT, suppliercontract_code TEXT, rrd_id TEXT, gi_id TEXT, dlv_prc TEXT, fix_tariff_date_from TEXT, fix_tariff_date_to TEXT, subject_name TEXT, nm_id TEXT, brand_name TEXT, sa_name TEXT, ts_name TEXT, barcode TEXT, doc_type_name TEXT, quantity TEXT, retail_price TEXT, retail_amount TEXT, sale_percent TEXT, commission_percent TEXT, office_name TEXT, supplier_oper_name TEXT, order_dt TEXT, sale_dt TEXT, rr_dt TEXT, shk_id TEXT, retail_price_withdisc_rub TEXT, delivery_amount TEXT, return_amount TEXT, delivery_rub TEXT, gi_box_type_name TEXT, product_discount_for_report TEXT, supplier_promo TEXT, ppvz_spp_prc TEXT, ppvz_kvw_prc_base TEXT, ppvz_kvw_prc TEXT, sup_rating_prc_up TEXT, is_kgvp_v2 TEXT, ppvz_sales_commission TEXT, ppvz_for_pay TEXT, ppvz_reward TEXT, acquiring_fee TEXT, acquiring_percent TEXT, payment_processing TEXT, acquiring_bank TEXT, ppvz_vw TEXT, ppvz_vw_nds TEXT, ppvz_office_name TEXT, ppvz_office_id TEXT, ppvz_supplier_id TEXT, ppvz_supplier_name TEXT, ppvz_inn TEXT, declaration_number TEXT, bonus_type_name TEXT, sticker_id TEXT, site_country TEXT, srv_dbs TEXT, penalty TEXT, additional_payment TEXT, rebill_logistic_cost TEXT, rebill_logistic_org TEXT, storage_fee TEXT, deduction TEXT, acceptance TEXT, assembly_id TEXT, kiz TEXT, srid TEXT, report_type TEXT, is_legal_entity TEXT, trbx_id TEXT, installment_cofinancing_amount TEXT, wibes_wb_discount_percent TEXT, cashback_amount TEXT, cashback_discount TEXT, PRIMARY KEY (org_id, rrd_id));

--- a/src/finmodel/scripts/katalog.py
+++ b/src/finmodel/scripts/katalog.py
@@ -181,7 +181,8 @@ def main() -> None:
         chrtID INTEGER,
         createdAt TEXT,
         updatedAt TEXT,
-        PRIMARY KEY (org_id, chrtID)
+        snapshot_date TEXT NOT NULL DEFAULT (CURRENT_DATE),
+        PRIMARY KEY (org_id, chrtID, snapshot_date)
     );
     """
     )
@@ -205,7 +206,6 @@ def main() -> None:
         logger.info("→ Организация: %s (ID=%s)", org_name, org_id)
         headers = headers_template.copy()
         headers["Authorization"] = token
-
 
         fetch_cards(cursor, conn, org_id, org_name, headers, active_url, "active")
         fetch_cards(cursor, conn, org_id, org_name, headers, trash_url, "trash")


### PR DESCRIPTION
## Summary
- add `snapshot_date` to `katalog` table schema
- provide SQL migration script to rebuild `katalog` with new composite primary key
- document migration steps in README

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7441417b8832aa0282f99f7dbeba9