### PR TITLE
Document scheduler setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,10 +363,34 @@ docker-compose up --build
 docker run --rm -v C:\path\to\config.yml:/app/config.yml \
   -v C:\path\to\Настройки.xlsm:/app/Настройки.xlsm \
   -v C:\path\to\finmodel.db:/app/finmodel.db \
-  finmodel
+ finmodel
 ```
 
 Настройте триггер с нужным интервалом.
+
+Для автоматической регистрации задачи используйте скрипт `devtools\setup_scheduler.ps1`:
+
+```powershell
+# ежедневный запуск в 03:00 под текущей учётной записью
+devtools\setup_scheduler.ps1 -DailyTime 03:00
+
+# запуск от имени другого пользователя
+devtools\setup_scheduler.ps1 -DailyTime 06:30 -Username "DOMAIN\user" -Password "Secret"
+```
+
+Параметр `-DailyTime` задаёт время запуска (часы:минуты). Через `-Username` и `-Password`
+можно указать учётную запись. По умолчанию задача создаётся под текущим пользователем
+с именем `FinmodelImport`.
+
+Удалить задачу можно командами:
+
+```powershell
+# через скрипт
+devtools\setup_scheduler.ps1 -Remove
+
+# напрямую через Планировщик задач
+schtasks /Delete /TN "FinmodelImport" /F
+```
 
 ## Разработка
 - Следуйте инструкциям в `AGENTS.md` по стандартам кодирования и тестированию


### PR DESCRIPTION
## Summary
- document how to automate task scheduling on Windows using `devtools/setup_scheduler.ps1`
- explain options for setting time/credentials and removing the task

## Testing
- `black --check .` *(fails: would reformat /workspace/Finmodel-2.0/tests/utils/test_db_load.py, /workspace/Finmodel-2.0/src/finmodel/scripts/wb_goods_prices_import_flat.py)*
- `isort --check-only .` *(fails: Imports are incorrectly sorted and/or formatted in src/finmodel/utils/db_load.py)*
- `python -m compileall -q .`
- `pytest` *(fails: tests/scripts/test_wb_goods_prices_import_flat.py::test_import_prices_inserts_rows)*

------
https://chatgpt.com/codex/tasks/task_e_68a83b2f8a28832aab80d712878afc1b