### PR TITLE
Store SPP history and purge outdated records

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,15 @@ psql -d finmodel -f migrations/20240706_add_snapshot_date_to_katalog.sql
 
 
    ```bash
-   python -m finmodel.scripts.wb_goods_prices_import_flat \
-     --txt nmids.txt \
-     --api-key "$WB_TOKEN" \
-     --out-sqlite prices.db
-   ```
+    python -m finmodel.scripts.wb_goods_prices_import_flat \
+      --txt nmids.txt \
+      --api-key "$WB_TOKEN" \
+      --out-sqlite prices.db
+    ```
+
+Скрипт `wb_spp_fetch` запрашивает SPP для `nmID` из таблицы `katalog` и
+сохраняет результаты в таблицу `wb_spp`. Каждый запуск добавляет новую строку с
+меткой времени, а записи старше одного месяца удаляются.
 
 ## Конфигурация
 

--- a/src/finmodel/scripts/wb_spp_fetch.py
+++ b/src/finmodel/scripts/wb_spp_fetch.py
@@ -35,7 +35,8 @@ BATCH_SIZE = 100
 # ──────────────────────────────────────────────────────────────────────────────
 CREATE_WB_SPP_SQL = """
 CREATE TABLE IF NOT EXISTS wb_spp (
-    nmID         INTEGER PRIMARY KEY,
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    nmID         INTEGER NOT NULL,
     priceU       INTEGER NOT NULL,
     salePriceU   INTEGER NOT NULL,
     sale_pct     INTEGER NOT NULL,
@@ -44,15 +45,11 @@ CREATE TABLE IF NOT EXISTS wb_spp (
 );
 """
 
+CLEANUP_SQL = "DELETE FROM wb_spp " "WHERE updated_at < datetime('now', '-1 month');"
+
 INSERT_SQL = """
 INSERT INTO wb_spp (nmID, priceU, salePriceU, sale_pct, spp, updated_at)
-VALUES (?, ?, ?, ?, ?, datetime('now'))
-ON CONFLICT(nmID) DO UPDATE SET
-    priceU       = excluded.priceU,
-    salePriceU   = excluded.salePriceU,
-    sale_pct     = excluded.sale_pct,
-    spp          = excluded.spp,
-    updated_at   = excluded.updated_at;
+VALUES (?, ?, ?, ?, ?, datetime('now'));
 """
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -113,6 +110,7 @@ def main() -> None:
         cur = con.cursor()
         try:
             cur.execute(CREATE_WB_SPP_SQL)
+            cur.execute(CLEANUP_SQL)
 
             try:
                 nm_ids = get_nm_ids(cur)

--- a/tests/scripts/test_wb_goods_prices_import_flat.py
+++ b/tests/scripts/test_wb_goods_prices_import_flat.py
@@ -87,7 +87,8 @@ def test_import_prices_inserts_rows(monkeypatch):
     assert row[7] == 900
     assert row[8] == pytest.approx(10)
     assert row[9] == pytest.approx(0)
-    assert row[10] == datetime.now(timezone.utc).date().isoformat()
+    assert row[10].startswith(datetime.now(timezone.utc).date().isoformat())
+    assert row[11] == datetime.now(timezone.utc).date().isoformat()
 
 
 def test_main_uses_xls_tokens(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- allow `wb_spp` to keep multiple entries per `nmID` by adding an auto-incrementing `id`
- drop upsert logic and prune rows older than a month before inserting new SPP data
- document monthly retention of `wb_spp` records
- fix goods prices test to match timestamp column order

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a845573c4c832a8d5cb7fd5b5a188c