### PR TITLE
Reorder scheduler script parameters

### DIFF
--- a/setup_scheduler.ps1
+++ b/setup_scheduler.ps1
@@ -1,9 +1,7 @@
-#!/usr/bin/env pwsh
-Set-StrictMode -Version Latest
-
 param(
     [string]$SchedulePath = "schedule.yml"
 )
+Set-StrictMode -Version Latest
 
 if (-not (Test-Path $SchedulePath)) {
     Write-Error "Schedule file '$SchedulePath' not found. Copy schedule.example.yml to schedule.yml and edit."


### PR DESCRIPTION
## Summary
- Move `param` block to the top of `setup_scheduler.ps1`
- Apply `Set-StrictMode -Version Latest` immediately after parameters

## Testing
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85c14e5c4832aa944ebdaa726d18a