### PR TITLE
Document scheduler requirements and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,43 +362,37 @@ docker-compose up --build
 
 ### Windows (Планировщик задач)
 
+Для запуска скриптов требуется PowerShell 7 (с встроенной `ConvertFrom-Yaml`) либо модуль [`powershell-yaml`](https://www.powershellgallery.com/packages/powershell-yaml).
 
-Для автоматического запуска используйте скрипт:
+#### YAML-конфигурация
+
+Скрипт `setup_scheduler.ps1` в корне репозитория читает файл `schedule.yml` и создаёт задачи по его содержимому. Используйте его, когда нужно управлять несколькими заданиями через один YAML-файл.
 
 ```powershell
-devtools\setup_scheduler.ps1
-
+Copy-Item schedule.example.yml schedule.yml
+# отредактируйте расписание
+./setup_scheduler.ps1
 ```
 
-Скрипт регистрирует ежедневные, еженедельные и повторяющиеся задания через `schtasks`. Время запуска и учётные данные можно передать параметрами. Чтобы удалить задачи, выполните:
+#### Параметры командной строки
+
+Скрипт `devtools\setup_scheduler.ps1` создаёт отдельные задачи, задаваемые аргументами. Подходит для быстрого создания и удаления задач.
+
+```powershell
+# еженедельный запуск по понедельникам в 07:30
+devtools\setup_scheduler.ps1 -WeeklyDay MON -WeeklyTime 07:30
+
+# запуск каждые 2 часа, начиная с 08:00
+devtools\setup_scheduler.ps1 -IntervalStart 08:00 -IntervalMinutes 120
+
+# ежедневный запуск в 03:00 под текущей учётной записью
+devtools\setup_scheduler.ps1 -DailyTime 03:00
+```
+
+Чтобы удалить созданные задачи, выполните:
 
 ```powershell
 devtools\setup_scheduler.ps1 -Cleanup
-```
-
-
-Для автоматической регистрации задачи используйте скрипт `devtools\setup_scheduler.ps1`:
-
-```powershell
-# ежедневный запуск в 03:00 под текущей учётной записью
-devtools\setup_scheduler.ps1 -DailyTime 03:00
-
-# запуск от имени другого пользователя
-devtools\setup_scheduler.ps1 -DailyTime 06:30 -Username "DOMAIN\user" -Password "Secret"
-```
-
-Параметр `-DailyTime` задаёт время запуска (часы:минуты). Через `-Username` и `-Password`
-можно указать учётную запись. По умолчанию задача создаётся под текущим пользователем
-с именем `FinmodelImport`.
-
-Удалить задачу можно командами:
-
-```powershell
-# через скрипт
-devtools\setup_scheduler.ps1 -Remove
-
-# напрямую через Планировщик задач
-schtasks /Delete /TN "FinmodelImport" /F
 ```
 
 


### PR DESCRIPTION
## Summary
- clarify PowerShell 7 or `powershell-yaml` requirements for scheduler scripts
- explain when to use YAML-based `setup_scheduler.ps1` vs parameter-based `devtools/setup_scheduler.ps1`
- add weekly and interval examples for Windows Task Scheduler

## Testing
- `black --check .` *(fails: would reformat tests/utils/test_db_load.py, src/finmodel/scripts/wb_goods_prices_import_flat.py)*
- `isort --check-only .` *(fails: src/finmodel/utils/db_load.py imports not sorted)*
- `python -m compileall -q .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85c22aaf4832aa11996251d0a00dd