### PR TITLE
Check for ConvertFrom-Yaml in scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ docker-compose up --build
 ## Планирование
 Для регулярного импорта данных запланируйте выполнение контейнера.
 
+В репозитории есть пример `schedule.example.yml` и скрипт `setup_scheduler.ps1`,
+который создаёт задачи по YAML-расписанию. Для чтения файла требуется модуль
+PowerShell `powershell-yaml` (командлет `ConvertFrom-Yaml`).
+
 ### Linux (cron)
 Выполните `crontab -e` и добавьте строку:
 

--- a/setup_scheduler.ps1
+++ b/setup_scheduler.ps1
@@ -1,9 +1,19 @@
 #!/usr/bin/env pwsh
+# Requires module 'powershell-yaml' for ConvertFrom-Yaml.
 Set-StrictMode -Version Latest
 
 param(
     [string]$SchedulePath = "schedule.yml"
 )
+
+if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+    try {
+        Import-Module powershell-yaml -ErrorAction Stop
+    } catch {
+        Write-Error "ConvertFrom-Yaml not found. Install the 'powershell-yaml' module: Install-Module powershell-yaml"
+        exit 1
+    }
+}
 
 if (-not (Test-Path $SchedulePath)) {
     Write-Error "Schedule file '$SchedulePath' not found. Copy schedule.example.yml to schedule.yml and edit."


### PR DESCRIPTION
## Summary
- ensure setup_scheduler.ps1 checks for ConvertFrom-Yaml and imports powershell-yaml when available
- document powershell-yaml requirement in script and README

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a85c15144c832a9be98ef395e4ca1a