### PR TITLE
Fix param placement in scheduler script

### DIFF
--- a/setup_scheduler.ps1
+++ b/setup_scheduler.ps1
@@ -1,12 +1,8 @@
-
 #!/usr/bin/env pwsh
-# Requires module 'powershell-yaml' for ConvertFrom-Yaml.
-Set-StrictMode -Version Latest
-
-
 param(
     [string]$SchedulePath = "schedule.yml"
 )
+# Requires module 'powershell-yaml' for ConvertFrom-Yaml.
 Set-StrictMode -Version Latest
 
 if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
## Summary
- ensure `setup_scheduler.ps1` declares the parameter block before enabling strict mode

## Testing
- `isort .`
- `black .`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a83888625c832a9f1c516413c31afb