### PR TITLE
Add wrapper script for scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,17 @@ PowerShell `powershell-yaml` (командлет `ConvertFrom-Yaml`).
 
 Для запуска скриптов требуется PowerShell 7 (с встроенной `ConvertFrom-Yaml`) либо модуль [`powershell-yaml`](https://www.powershellgallery.com/packages/powershell-yaml).
 
+Скрипт-обёртка `run_finmodel_task.ps1` запускает контейнер с указанным именем задачи
+и устанавливает переменную окружения `FINMODEL_SCRIPT`. Его можно вызвать вручную
+или через Планировщик задач:
+
+```powershell
+./run_finmodel_task.ps1 saleswb_import_flat
+```
+
+`setup_scheduler.ps1` использует эту обёртку при создании задач, чтобы команда в
+Планировщике была короче и не превышала ограничение в 261 символ.
+
 #### YAML-конфигурация
 
 Скрипт `setup_scheduler.ps1` в корне репозитория читает файл `schedule.yml` и создаёт задачи по его содержимому. Используйте его, когда нужно управлять несколькими заданиями через один YAML-файл.

--- a/run_finmodel_task.ps1
+++ b/run_finmodel_task.ps1
@@ -1,0 +1,15 @@
+#!/usr/bin/env pwsh
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptName
+)
+
+Set-StrictMode -Version Latest
+
+docker run --rm \
+    -v "${PWD}\config.yml:/app/config.yml" \
+    -v "${PWD}\Настройки.xlsm:/app/Настройки.xlsm" \
+    -v "${PWD}\finmodel.db:/app/finmodel.db" \
+    -e "FINMODEL_SCRIPT=finmodel.scripts.$ScriptName" \
+    finmodel
+

--- a/setup_scheduler.ps1
+++ b/setup_scheduler.ps1
@@ -32,14 +32,8 @@ foreach ($item in $schedule.GetEnumerator()) {
     $minuteField = $parts[0]
     $hourField = $parts[1]
 
-    $action = @(
-        "docker run --rm",
-        "-v ${PWD}\config.yml:/app/config.yml",
-        "-v ${PWD}\Настройки.xlsm:/app/Настройки.xlsm",
-        "-v ${PWD}\finmodel.db:/app/finmodel.db",
-        "-e FINMODEL_SCRIPT=finmodel.scripts.$name",
-        "finmodel"
-    ) -join ' '
+    $scriptPath = Join-Path $PWD "run_finmodel_task.ps1"
+    $action = "`"$scriptPath`" $name"
 
     $args = @("/Create", "/TN", $name, "/TR", $action)
 


### PR DESCRIPTION
## Summary
- add run_finmodel_task.ps1 to invoke docker tasks
- simplify setup_scheduler.ps1 to call wrapper
- document wrapper usage in README

## Testing
- `isort .`
- `black .`
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a872e83edc832a875062ad0f21853b