### PR TITLE
Validate minutes_after before scheduling

### DIFF
--- a/src/finmodel/utils/scheduler.py
+++ b/src/finmodel/utils/scheduler.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from threading import Timer
+from typing import Any, Callable
+
+from finmodel.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def schedule_after_meal(callback: Callable[[], Any], minutes_after: float) -> Timer | None:
+    """Schedule a callback to run after a given number of minutes.
+
+    The function validates that ``minutes_after`` is a positive number before scheduling.
+    If validation fails, an error is logged and the function returns ``None``.
+
+    Parameters
+    ----------
+    callback: Callable
+        A function to execute after the delay.
+    minutes_after: float
+        Number of minutes to wait before executing ``callback``.
+
+    Returns
+    -------
+    Timer | None
+        The scheduled :class:`threading.Timer` instance or ``None`` if validation fails.
+    """
+    if not isinstance(minutes_after, (int, float)) or minutes_after <= 0:
+        logger.error("minutes_after must be a positive number, got %r", minutes_after)
+        return None
+
+    timer = Timer(minutes_after * 60, callback)
+    timer.start()
+    return timer

--- a/tests/utils/test_scheduler.py
+++ b/tests/utils/test_scheduler.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure src is importable
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from finmodel.utils.scheduler import schedule_after_meal
+
+
+def dummy_callback() -> None:  # pragma: no cover - simple placeholder
+    pass
+
+
+@pytest.mark.parametrize("minutes_after", [0, -5, "ten", None])
+def test_schedule_after_meal_invalid(minutes_after, caplog):
+    caplog.set_level("ERROR")
+    timer = schedule_after_meal(dummy_callback, minutes_after)  # type: ignore[arg-type]
+    assert timer is None
+    assert "minutes_after" in caplog.text


### PR DESCRIPTION
## Summary
- add scheduler utility with validation for minutes_after
- cover invalid minutes_after in schedule_after_meal tests

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b54c64ee68832a9c5676cecb03356f