### PR TITLE
Use timezone-aware Timestamp in parse_date

### DIFF
--- a/src/finmodel/utils/settings.py
+++ b/src/finmodel/utils/settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
+from datetime import datetime, tzinfo
 from pathlib import Path
 from typing import Any, Dict
 
@@ -47,20 +47,20 @@ def find_setting(name: str, default: Any | None = None) -> Any:
     return os.getenv(name) or cfg.get(name, default)
 
 
-def parse_date(dt) -> datetime:
-    """Parse various date formats into ``datetime``.
+def parse_date(dt, tz: str | tzinfo | None = None) -> pd.Timestamp:
+    """Parse various date formats into a timezone-aware ``pd.Timestamp``.
 
     Supports ``dd.mm.yyyy``, ``yyyy-mm-dd`` and arbitrary ISO-like formats.
+    The returned timestamp is in UTC unless ``tz`` is provided to convert it to
+    another timezone.
     """
     s = str(dt).replace("T", " ").replace("/", ".").strip()
     if s == "":
         raise ValueError("empty date")
-    for fmt in ("%d.%m.%Y", "%Y-%m-%d"):
-        try:
-            return datetime.strptime(s, fmt)
-        except ValueError:
-            continue
-    return pd.to_datetime(s).to_pydatetime()
+    ts = pd.to_datetime(s, utc=True, dayfirst="." in s)
+    if tz is not None:
+        ts = ts.tz_convert(tz)
+    return ts
 
 
 def load_organizations(path: str | Path | None = None, sheet: str | None = None) -> pd.DataFrame:

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -1,4 +1,3 @@
-import datetime
 import sys
 from pathlib import Path
 
@@ -19,13 +18,18 @@ from finmodel.utils.settings import (
 @pytest.mark.parametrize(
     "raw, expected",
     [
-        ("01.02.2023", datetime.datetime(2023, 2, 1)),
-        ("2023-02-01", datetime.datetime(2023, 2, 1)),
-        ("2023-02-01T13:45:00", datetime.datetime(2023, 2, 1, 13, 45, 0)),
+        ("01.02.2023", pd.Timestamp("2023-02-01", tz="UTC")),
+        ("2023-02-01", pd.Timestamp("2023-02-01", tz="UTC")),
+        ("2023-02-01T13:45:00", pd.Timestamp("2023-02-01T13:45:00", tz="UTC")),
     ],
 )
 def test_parse_date(raw, expected):
     assert parse_date(raw) == expected
+
+
+def test_parse_date_with_timezone():
+    result = parse_date("2023-02-01", tz="Europe/Moscow")
+    assert result == pd.Timestamp("2023-02-01T03:00:00", tz="Europe/Moscow")
 
 
 def test_load_organizations_missing_columns(tmp_path):


### PR DESCRIPTION
## Summary
- parse dates with `pd.to_datetime(..., utc=True)` and allow optional timezone conversion
- test that `parse_date` yields timezone-aware timestamps

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8259ffff0832a94df0533c09e4c0f